### PR TITLE
TASK: Improve metadata handling

### DIFF
--- a/Classes/Domain/AggregateRootInterface.php
+++ b/Classes/Domain/AggregateRootInterface.php
@@ -24,10 +24,10 @@ interface AggregateRootInterface
     public function getAggregateIdentifier(): string;
 
     /**
-     * @param EventInterface $event
-     * @return void
+     * @param  EventInterface $event
+     * @param  array $metadata
      */
-    public function recordThat(EventInterface $event);
+    public function recordThat(EventInterface $event, array $metadata = []);
 
     /**
      * @return array

--- a/Classes/Domain/AggregateRootTrait.php
+++ b/Classes/Domain/AggregateRootTrait.php
@@ -77,7 +77,7 @@ trait AggregateRootTrait
             $messageMetadata->add($name, $value);
         }
 
-        $this->apply($event, $messageMetadata);
+        $this->apply($event);
 
         $this->events[] = new EventTransport($event, $messageMetadata);
     }
@@ -96,7 +96,7 @@ trait AggregateRootTrait
      * @param  EventInterface $event
      * @return void
      */
-    protected function apply(EventInterface $event, MessageMetadata $metadata)
+    protected function apply(EventInterface $event)
     {
         $name = EventType::get($event);
 
@@ -114,6 +114,6 @@ trait AggregateRootTrait
             ));
         }
 
-        $this->$method($event, $metadata);
+        $this->$method($event);
     }
 }


### PR DESCRIPTION
This change introduce a second parameter for the recordThat method to allow setting metadata to the EventTransport object.