### PR TITLE
TASK: recordThat() sets aggregate id on event

### DIFF
--- a/Classes/Domain/AbstractAggregateRoot.php
+++ b/Classes/Domain/AbstractAggregateRoot.php
@@ -11,6 +11,7 @@ namespace Neos\Cqrs\Domain;
  * source code.
  */
 
+use Neos\Cqrs\Event\AggregateEventInterface;
 use Neos\Cqrs\Event\EventInterface;
 use Neos\Cqrs\Event\EventTransport;
 use Neos\Cqrs\Event\EventType;
@@ -62,16 +63,17 @@ abstract class AbstractAggregateRoot implements AggregateRootInterface
      * Apply an event to the current aggregate root
      *
      * If the event aggregate identifier and name is not set the event
-     * if automatically updated with the current aggregate identifier
+     * is automatically set with the current aggregate identifier
      * and name.
      *
-     * @param  EventInterface $event
-     * @param  array $metadata
-     * @return void
+     * @param AggregateEventInterface $event
+     * @param array $metadata
      * @api
      */
-    public function recordThat(EventInterface $event, array $metadata = [])
+    public function recordThat(AggregateEventInterface $event, array $metadata = [])
     {
+        $event->setAggregateIdentifier($this->getAggregateIdentifier());
+
         $messageMetadata = new MessageMetadata($metadata);
         foreach ($metadata as $name => $value) {
             $messageMetadata->add($name, $value);

--- a/Classes/Domain/AggregateRootInterface.php
+++ b/Classes/Domain/AggregateRootInterface.php
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\Domain;
  * source code.
  */
 
-use Neos\Cqrs\Event\EventInterface;
+use Neos\Cqrs\Event\AggregateEventInterface;
 
 /**
  * AggregateRootInterface
@@ -24,10 +24,10 @@ interface AggregateRootInterface
     public function getAggregateIdentifier(): string;
 
     /**
-     * @param  EventInterface $event
-     * @param  array $metadata
+     * @param AggregateEventInterface $event
+     * @param array $metadata
      */
-    public function recordThat(EventInterface $event, array $metadata = []);
+    public function recordThat(AggregateEventInterface $event, array $metadata = []);
 
     /**
      * @return array

--- a/Classes/Event/AbstractAggregateEvent.php
+++ b/Classes/Event/AbstractAggregateEvent.php
@@ -1,0 +1,52 @@
+<?php
+namespace Neos\Cqrs\Event;
+
+/*
+ * This file is part of the Neos.Cqrs package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+use Neos\Cqrs\Exception;
+
+/**
+ * Base class for events which are related to aggregates
+ */
+abstract class AbstractAggregateEvent implements AggregateEventInterface
+{
+    /**
+     * @var string
+     */
+    protected $aggregateIdentifier;
+
+    /**
+     * Returns the identifier of the aggregate the event is related to
+     *
+     * @return string
+     */
+    public function getAggregateIdentifier(): string
+    {
+        return $this->aggregateIdentifier;
+    }
+
+    /**
+     * Sets the aggregate identifier for this event.
+     *
+     * This method can only be called once per event instance. It is usually invoked by the recordThat() method in
+     * a concrete aggregate object.
+     *
+     * @param $aggregateIdentifier
+     * @return void
+     * @throws Exception
+     */
+    public function setAggregateIdentifier($aggregateIdentifier)
+    {
+        if ($this->aggregateIdentifier !== null) {
+            throw new Exception(sprintf('The aggregate identifier of this %s has already been set (%s) and can only be set once.', get_class($this), $this->aggregateIdentifier), 1474969482419);
+        }
+        $this->aggregateIdentifier = $aggregateIdentifier;
+    }
+}

--- a/Classes/Event/AggregateEventInterface.php
+++ b/Classes/Event/AggregateEventInterface.php
@@ -1,0 +1,38 @@
+<?php
+namespace Neos\Cqrs\Event;
+
+/*
+ * This file is part of the Neos.Cqrs package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+use Neos\Cqrs\Exception;
+
+/**
+ * Interface for events which are related to aggregates
+ */
+interface AggregateEventInterface extends EventInterface
+{
+    /**
+     * Returns the identifier of the aggregate the event is related to
+     *
+     * @return string
+     */
+    public function getAggregateIdentifier(): string;
+
+    /**
+     * Sets the aggregate identifier for this event.
+     *
+     * This method can only be called once per event instance. It is usually invoked by the recordThat() method in
+     * a concrete aggregate object.
+     *
+     * @param $aggregateIdentifier
+     * @return void
+     * @throws Exception
+     */
+    public function setAggregateIdentifier($aggregateIdentifier);
+}


### PR DESCRIPTION
This changes the behaviour of recordThat() and the EventInterface.

With this change applied, you don't have to specify the aggregate identifier anymore when calling `recordThat()`. A new interface and abstract class for events provides a getter and setter for the aggregate identifier and makes sure that an identifier can't be changed once it has been set.

Example:
```php
    /**
     * Create a new organization
     *
     * @param string $name
     * @param string $slug
     * @param string $primaryOwnerUserIdentifier Identifier of the primary owner user for the new organisation
     * @return static
     */
    static public function create($name, $slug, $primaryOwnerUserIdentifier)
    {
        $instance = new static();
        $instance->recordThat(new OrganizationHasBeenCreated($name, $slug, $primaryOwnerUserIdentifier));
        return $instance;
    }
```

and

```php
use Neos\Cqrs\Event\AbstractAggregateEvent;

/**
 * OrganizationHasBeenCreated
 */
class OrganizationHasBeenCreated extends AbstractAggregateEvent
{
    /**
     * @var string
     */
    protected $name;

    /**
     * @var string
     */
    protected $slug;

    /**
     * @var string
     */
    protected $primaryOwnerIdentifier;

    /**
     * OrganizationHasBeenCreated constructor.
     *
     * @param string $name
     * @param string $slug
     * @param string $primaryOwnerIdentifier
     */
    public function __construct(string $name, string $slug, string $primaryOwnerIdentifier)
    {
        $this->name = $name;
        $this->slug = $slug;
        $this->primaryOwnerIdentifier = $primaryOwnerIdentifier;
    }
…
```