### PR TITLE
TASK: Handle Aggregate Identifier in Framework

### DIFF
--- a/Classes/Domain/AbstractAggregateRoot.php
+++ b/Classes/Domain/AbstractAggregateRoot.php
@@ -27,7 +27,7 @@ abstract class AbstractAggregateRoot implements AggregateRootInterface
     /**
      * @var string
      */
-    private $aggregateIdentifier;
+    protected $aggregateIdentifier;
 
     /**
      * @var EventTransport[]
@@ -35,12 +35,11 @@ abstract class AbstractAggregateRoot implements AggregateRootInterface
     private $events = [];
 
     /**
-     * @param string $identifier
-     * @return void
+     * @param string $aggregateIdentifier
      */
-    final protected function setAggregateIdentifier($identifier)
+    protected function __construct(string $aggregateIdentifier)
     {
-        $this->aggregateIdentifier = $identifier;
+        $this->aggregateIdentifier = $aggregateIdentifier;
     }
 
     /**

--- a/Classes/Domain/AbstractEventSourcedAggregateRoot.php
+++ b/Classes/Domain/AbstractEventSourcedAggregateRoot.php
@@ -33,11 +33,7 @@ abstract class AbstractEventSourcedAggregateRoot extends AbstractAggregateRoot i
 
         /** @var EventTransport $eventTransport */
         foreach ($stream as $eventTransport) {
-            $event = $eventTransport->getEvent();
-            if ($event instanceof AggregateEventInterface) {
-                $this->setAggregateIdentifier($event->getAggregateIdentifier());
-            }
-            $this->apply($event);
+            $this->apply($eventTransport->getEvent());
         }
     }
 }

--- a/Classes/EventStore/EventSourcedRepository.php
+++ b/Classes/EventStore/EventSourcedRepository.php
@@ -69,8 +69,7 @@ abstract class EventSourcedRepository implements RepositoryInterface
             throw new AggregateRootNotFoundException(sprintf("Could not reconstitute the aggregate root %s because its class '%s' does not exist.", $identifier, $this->aggregateClassName), 1474454928115);
         }
 
-        $aggregateRoot = unserialize('O:' . strlen($this->aggregateClassName) . ':"' . $this->aggregateClassName . '":0:{};');
-
+        $aggregateRoot = unserialize('O:' . strlen($this->aggregateClassName) . ':"' . $this->aggregateClassName . '":1:{s:22:"' . chr(0) . '*' . chr(0) . 'aggregateIdentifier";s:36:"' . $identifier . '";}');
         if (!$aggregateRoot instanceof EventSourcedAggregateRootInterface) {
             throw new AggregateRootNotFoundException(sprintf("Could not reconstitute the aggregate root '%s' with id '%s' because it does not implement the EventSourcedAggregateRootInterface.", $this->aggregateClassName, $identifier, $this->aggregateClassName), 1474464335530);
         }


### PR DESCRIPTION
Adjusts the `AbstractAggregateRoot` to expect an `aggregateIdentifier` in the (protected) constructor.
The aggregate instanciation can be done with an overridden constructor or, preferably, with a static method:

	static public function create(string $aggregateIdentifier, string $someParam) : SomeAggregate {
		$aggregate = new SomeAggregate($aggregateIdentifier);
		$aggregate->recordThat(
			new SomeAggretateWasCreated(
				$someParam
			)
		);
	}

Resolves: #46