### PR TITLE
TASK: Rename aggregate identifier to identifier

### DIFF
--- a/Classes/Domain/AbstractAggregateRoot.php
+++ b/Classes/Domain/AbstractAggregateRoot.php
@@ -27,7 +27,7 @@ abstract class AbstractAggregateRoot implements AggregateRootInterface
     /**
      * @var string
      */
-    protected $aggregateIdentifier;
+    protected $identifier;
 
     /**
      * @var EventTransport[]
@@ -35,19 +35,19 @@ abstract class AbstractAggregateRoot implements AggregateRootInterface
     private $events = [];
 
     /**
-     * @param string $aggregateIdentifier
+     * @param string $identifier
      */
-    protected function __construct(string $aggregateIdentifier)
+    protected function __construct(string $identifier)
     {
-        $this->aggregateIdentifier = $aggregateIdentifier;
+        $this->identifier = $identifier;
     }
 
     /**
      * @return string
      */
-    final public function getAggregateIdentifier(): string
+    final public function getIdentifier(): string
     {
-        return $this->aggregateIdentifier;
+        return $this->identifier;
     }
 
     /**
@@ -63,7 +63,7 @@ abstract class AbstractAggregateRoot implements AggregateRootInterface
      */
     final public function recordThat(AggregateEventInterface $event, array $metadata = [])
     {
-        $event->setAggregateIdentifier($this->getAggregateIdentifier());
+        $event->setAggregateIdentifier($this->getIdentifier());
 
         $messageMetadata = new MessageMetadata($metadata);
 

--- a/Classes/Domain/AbstractEventSourcedAggregateRoot.php
+++ b/Classes/Domain/AbstractEventSourcedAggregateRoot.php
@@ -11,7 +11,6 @@ namespace Neos\Cqrs\Domain;
  * source code.
  */
 
-use Neos\Cqrs\Event\AggregateEventInterface;
 use Neos\Cqrs\Event\EventTransport;
 use Neos\Cqrs\EventStore\EventStream;
 use Neos\Cqrs\RuntimeException;

--- a/Classes/Domain/AggregateRootInterface.php
+++ b/Classes/Domain/AggregateRootInterface.php
@@ -21,7 +21,7 @@ interface AggregateRootInterface
     /**
      * @return string
      */
-    public function getAggregateIdentifier(): string;
+    public function getIdentifier(): string;
 
     /**
      * @param AggregateEventInterface $event

--- a/Classes/EventStore/EventSourcedRepository.php
+++ b/Classes/EventStore/EventSourcedRepository.php
@@ -69,7 +69,7 @@ abstract class EventSourcedRepository implements RepositoryInterface
             throw new AggregateRootNotFoundException(sprintf("Could not reconstitute the aggregate root %s because its class '%s' does not exist.", $identifier, $this->aggregateClassName), 1474454928115);
         }
 
-        $aggregateRoot = unserialize('O:' . strlen($this->aggregateClassName) . ':"' . $this->aggregateClassName . '":1:{s:22:"' . chr(0) . '*' . chr(0) . 'aggregateIdentifier";s:36:"' . $identifier . '";}');
+        $aggregateRoot = unserialize('O:' . strlen($this->aggregateClassName) . ':"' . $this->aggregateClassName . '":1:{s:13:"' . chr(0) . '*' . chr(0) . 'identifier";s:36:"' . $identifier . '";}');
         if (!$aggregateRoot instanceof EventSourcedAggregateRootInterface) {
             throw new AggregateRootNotFoundException(sprintf("Could not reconstitute the aggregate root '%s' with id '%s' because it does not implement the EventSourcedAggregateRootInterface.", $this->aggregateClassName, $identifier, $this->aggregateClassName), 1474464335530);
         }
@@ -84,7 +84,7 @@ abstract class EventSourcedRepository implements RepositoryInterface
     public function save(AggregateRootInterface $aggregate)
     {
         try {
-            $stream = $this->eventStore->get($this->generateStreamName($aggregate->getAggregateIdentifier()));
+            $stream = $this->eventStore->get($this->generateStreamName($aggregate->getIdentifier()));
         } catch (EventStreamNotFoundException $e) {
             $stream = new EventStream();
         }
@@ -92,7 +92,7 @@ abstract class EventSourcedRepository implements RepositoryInterface
         $uncommittedEvents = $aggregate->pullUncommittedEvents();
         $stream->addEvents(...$uncommittedEvents);
 
-        $this->eventStore->commit($this->generateStreamName($aggregate->getAggregateIdentifier()), $stream, function ($version) use ($uncommittedEvents) {
+        $this->eventStore->commit($this->generateStreamName($aggregate->getIdentifier()), $stream, function ($version) use ($uncommittedEvents) {
             /** @var EventTransport $eventTransport */
             foreach ($uncommittedEvents as $eventTransport) {
                 // @todo metadata enrichment must be done in external service, with some middleware support

--- a/Readme.md
+++ b/Readme.md
@@ -68,23 +68,23 @@ Your command must simply implement the ```CommandInterface```.
         /**
          * @var string
          */
-        protected $aggregateIdentifier;
+        protected $identifier;
 
         /**
-         * @param string $aggregateIdentifier
+         * @param string $identifier
          * @param float $duration
          */
-        public function __construct(string $aggregateIdentifier)
+        public function __construct(string $identifier)
         {
-            $this->aggregateIdentifier = $aggregateIdentifier;
+            $this->identifier = $identifier;
         }
 
         /**
          * @return string
          */
-        public function getAggregateIdentifier(): string
+        public function getIdentifier(): string
         {
-            return $this->aggregateIdentifier;
+            return $this->identifier;
         }
     }
 
@@ -110,7 +110,7 @@ Your command must simply implement the ```CommandHandlerInterface```.
          */
         public function handleCreateButton(CreateButton $command)
         {
-            $button = new Button($command->getAggregateIdentifier(), $command->getPublicIdentifier());
+            $button = new Button($command->getIdentifier(), $command->getPublicIdentifier());
             $button->changeLabel($command->getLabel());
 
             $this->buttonRepository->save($button);


### PR DESCRIPTION
This change renames all usages of "aggregate identifier"
to just "identifier" where the context is clear.

Resolves: #49