### PR TITLE
FEATURE: Allow aggregates to handle identifiers

### DIFF
--- a/Classes/Domain/AbstractAggregateRoot.php
+++ b/Classes/Domain/AbstractAggregateRoot.php
@@ -57,13 +57,15 @@ abstract class AbstractAggregateRoot implements AggregateRootInterface
      * is automatically set with the current aggregate identifier
      * and name.
      *
-     * @param AggregateEventInterface $event
+     * @param EventInterface $event
      * @param array $metadata
      * @api
      */
-    final public function recordThat(AggregateEventInterface $event, array $metadata = [])
+    final public function recordThat(EventInterface $event, array $metadata = [])
     {
-        $event->setIdentifier($this->getIdentifier());
+        if ($event instanceof AggregateEventInterface) {
+            $event->setIdentifier($this->getIdentifier());
+        }
 
         $messageMetadata = new MessageMetadata($metadata);
 

--- a/Classes/Domain/AggregateRootInterface.php
+++ b/Classes/Domain/AggregateRootInterface.php
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\Domain;
  * source code.
  */
 
-use Neos\Cqrs\Event\AggregateEventInterface;
+use Neos\Cqrs\Event\EventInterface;
 
 /**
  * AggregateRootInterface
@@ -24,10 +24,10 @@ interface AggregateRootInterface
     public function getIdentifier(): string;
 
     /**
-     * @param AggregateEventInterface $event
+     * @param EventInterface $event
      * @param array $metadata
      */
-    public function recordThat(AggregateEventInterface $event, array $metadata = []);
+    public function recordThat(EventInterface $event, array $metadata = []);
 
     /**
      * @return array


### PR DESCRIPTION
This change allows for aggregates to record events that do not
implement the `AggregateEventInterface`.

Resolves: #51