### PR TITLE
FEATURE: Allow retrieval of read model instances in doctrine projectors

### DIFF
--- a/Classes/Projection/Doctrine/AbstractDoctrineProjector.php
+++ b/Classes/Projection/Doctrine/AbstractDoctrineProjector.php
@@ -11,6 +11,7 @@ namespace Neos\Cqrs\Projection\Doctrine;
  * source code.
  */
 
+use Neos\Cqrs\Exception;
 use Neos\Cqrs\Projection\AbstractBaseProjector;
 use TYPO3\Flow\Annotations as Flow;
 
@@ -32,12 +33,29 @@ abstract class AbstractDoctrineProjector extends AbstractBaseProjector
      * Make sure to call this method as parent when overriding it in a concrete projector.
      *
      * @return void
+     * @throws Exception
      */
     protected function initializeObject()
     {
-        if ($this->readModelClassName === null && substr(get_class($this), -9, 9) === 'Projector') {
+        if ($this->readModelClassName === null) {
+            if (substr(get_class($this), -9, 9) !== 'Projector') {
+                throw new Exception(sprintf('The class name "%s" doesn\'t end in "Projector" so the Read Model class name can\'t be determined automatically. Please set the "readModelClassName" field it in your concrete projector.', get_class($this)), 1476799474);
+            }
             $this->readModelClassName = substr(get_class($this), 0, -9);
         }
+    }
+
+    /**
+     * Retrieves an object with the given $identifier.
+     * For use in the concrete projector.
+     *
+     * @param string $identifier
+     * @return object an instance of $this->readModelClassName or NULL if no matching object could be found
+     * @api
+     */
+    public function get(string $identifier)
+    {
+        return $this->projectionPersistenceManager->get($this->getReadModelClassName(), $identifier);
     }
 
     /**

--- a/Classes/Projection/Doctrine/DoctrineProjectionPersistenceManager.php
+++ b/Classes/Projection/Doctrine/DoctrineProjectionPersistenceManager.php
@@ -11,7 +11,8 @@ namespace Neos\Cqrs\Projection\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Persistence\ObjectManager as EntityManager;
+use Doctrine\Common\Persistence\ObjectManager as DoctrineObjectManager;
+use Doctrine\ORM\EntityManager as DoctrineEntityManager;
 use Doctrine\ORM\UnitOfWork;
 use Neos\Cqrs\Exception;
 use TYPO3\Flow\Log\SystemLoggerInterface;
@@ -33,10 +34,30 @@ class DoctrineProjectionPersistenceManager
     protected $systemLogger;
 
     /**
-     * @Flow\Inject
-     * @var EntityManager
+     * @var DoctrineEntityManager
      */
-    protected $entityManager;
+    private $entityManager;
+
+    /**
+     * @param DoctrineObjectManager $entityManager
+     * @return void
+     */
+    public function injectEntityManager(DoctrineObjectManager $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * Returns an object with the given $identifier from persistence.
+     *
+     * @param string $className
+     * @param string $identifier
+     * @return object
+     */
+    public function get(string $className, string $identifier)
+    {
+        return $this->entityManager->find($className, $identifier);
+    }
 
     /**
      * Adds an object for persistence.
@@ -89,7 +110,7 @@ class DoctrineProjectionPersistenceManager
      */
     public function drop(string $readModelClassName): int
     {
-        $query = $this->entityManager->createQuery('delete from ' . $readModelClassName . ' m where true');
+        $query = $this->entityManager->createQuery('DELETE FROM ' . $readModelClassName);
         return $query->execute();
     }
 
@@ -110,7 +131,6 @@ class DoctrineProjectionPersistenceManager
             $this->entityManager->flush();
         } catch (\Exception $exception) {
             $this->systemLogger->logException($exception);
-            /** @var Connection $connection */
             $connection = $this->entityManager->getConnection();
             $connection->close();
             $connection->connect();


### PR DESCRIPTION
Previously the `Finder` had to be used within doctrine projectors in order to *update* a read model.
This was not only error prone and cumbersome but didn't support retrieval of not yet persisted
objects because of the missing identity map.

Previously:
```php
/**
 * @Flow\Inject
 * @var SomeFinder
 **/
protected $someFinder;

public function whenSomethingHappened(SomethingHappened $event) {
    $readModel = $this->someFinder->findOneByIdentifier($event->getIdentifier());
    // ...
}
```

Now:
```php
public function whenSomethingHappened(SomethingHappened $event) {
    $readModel = $this->get($event->getIdentifier());
    // ...
}
```

Related: #13 