### PR TITLE
TASK: Use generic designators for stream & event names

### DIFF
--- a/Classes/EventStore/EventSourcedRepository.php
+++ b/Classes/EventStore/EventSourcedRepository.php
@@ -39,6 +39,12 @@ abstract class EventSourcedRepository implements RepositoryInterface
     protected $eventBus;
 
     /**
+     * @Flow\Inject
+     * @var EventStreamResolver
+     */
+    protected $eventStreamResolver;
+
+    /**
      * @var string
      */
     protected $aggregateClassName;
@@ -58,9 +64,9 @@ abstract class EventSourcedRepository implements RepositoryInterface
      */
     public function findByIdentifier($identifier)
     {
+        $streamName = $this->eventStreamResolver->getStreamNameForAggregateTypeAndIdentifier($this->aggregateClassName, $identifier);
         try {
-            /** @var EventStream $eventStream */
-            $eventStream = $this->eventStore->get($this->generateStreamName($identifier));
+            $eventStream = $this->eventStore->get($streamName);
         } catch (EventStreamNotFoundException $e) {
             return null;
         }
@@ -83,8 +89,9 @@ abstract class EventSourcedRepository implements RepositoryInterface
      */
     public function save(AggregateRootInterface $aggregate)
     {
+        $streamName = $this->eventStreamResolver->getStreamNameForAggregate($aggregate);
         try {
-            $stream = $this->eventStore->get($this->generateStreamName($aggregate->getIdentifier()));
+            $stream = $this->eventStore->get($streamName);
         } catch (EventStreamNotFoundException $e) {
             $stream = new EventStream();
         }
@@ -92,7 +99,7 @@ abstract class EventSourcedRepository implements RepositoryInterface
         $uncommittedEvents = $aggregate->pullUncommittedEvents();
         $stream->addEvents(...$uncommittedEvents);
 
-        $this->eventStore->commit($this->generateStreamName($aggregate->getIdentifier()), $stream, function ($version) use ($uncommittedEvents) {
+        $this->eventStore->commit($streamName, $stream, function ($version) use ($uncommittedEvents) {
             /** @var EventTransport $eventTransport */
             foreach ($uncommittedEvents as $eventTransport) {
                 // @todo metadata enrichment must be done in external service, with some middleware support
@@ -100,16 +107,5 @@ abstract class EventSourcedRepository implements RepositoryInterface
                 $this->eventBus->handle($eventTransport->withMetadata($versionedMetadata));
             }
         });
-    }
-
-    /**
-     * @param string $identifier
-     * @return string
-     * @todo find a more flexible way to generate stream name, need to be discussed
-     */
-    protected function generateStreamName(string $identifier)
-    {
-        $streamName = $this->aggregateClassName . '::' . $identifier;
-        return $streamName;
     }
 }

--- a/Classes/EventStore/EventSourcedRepository.php
+++ b/Classes/EventStore/EventSourcedRepository.php
@@ -40,9 +40,9 @@ abstract class EventSourcedRepository implements RepositoryInterface
 
     /**
      * @Flow\Inject
-     * @var EventStreamResolver
+     * @var StreamNameResolver
      */
-    protected $eventStreamResolver;
+    protected $streamNameResolver;
 
     /**
      * @var string
@@ -64,7 +64,7 @@ abstract class EventSourcedRepository implements RepositoryInterface
      */
     public function findByIdentifier($identifier)
     {
-        $streamName = $this->eventStreamResolver->getStreamNameForAggregateTypeAndIdentifier($this->aggregateClassName, $identifier);
+        $streamName = $this->streamNameResolver->getStreamNameForAggregateTypeAndIdentifier($this->aggregateClassName, $identifier);
         try {
             $eventStream = $this->eventStore->get($streamName);
         } catch (EventStreamNotFoundException $e) {
@@ -89,7 +89,7 @@ abstract class EventSourcedRepository implements RepositoryInterface
      */
     public function save(AggregateRootInterface $aggregate)
     {
-        $streamName = $this->eventStreamResolver->getStreamNameForAggregate($aggregate);
+        $streamName = $this->streamNameResolver->getStreamNameForAggregate($aggregate);
         try {
             $stream = $this->eventStore->get($streamName);
         } catch (EventStreamNotFoundException $e) {

--- a/Classes/EventStore/EventStreamResolver.php
+++ b/Classes/EventStore/EventStreamResolver.php
@@ -1,0 +1,60 @@
+<?php
+namespace Neos\Cqrs\EventStore;
+
+/*
+ * This file is part of the Neos.EventStore package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Cqrs\Domain\AggregateRootInterface;
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Package\PackageManagerInterface;
+use TYPO3\Flow\Reflection\ClassReflection;
+use TYPO3\Flow\Utility\TypeHandling;
+
+/**
+ * Central authority for resolving event stream names
+ *
+ * @Flow\Scope("singleton")
+ */
+class EventStreamResolver
+{
+    /**
+     * @var PackageManagerInterface
+     */
+    private $packageManager;
+
+    /**
+     * @param PackageManagerInterface $packageManager
+     */
+    public function __construct(PackageManagerInterface $packageManager)
+    {
+        $this->packageManager = $packageManager;
+    }
+
+    /**
+     * @param AggregateRootInterface $aggregate
+     * @return string
+     */
+    public function getStreamNameForAggregate(AggregateRootInterface $aggregate)
+    {
+        return $this->getStreamNameForAggregateTypeAndIdentifier(TypeHandling::getTypeForValue($aggregate), $aggregate->getIdentifier());
+    }
+
+    /**
+     * @param string $aggregateClassName
+     * @param string $aggregateIdentifier
+     * @return string
+     */
+    public function getStreamNameForAggregateTypeAndIdentifier(string $aggregateClassName, string $aggregateIdentifier)
+    {
+        $packageKey = $this->packageManager->getPackageByClassName($aggregateClassName)->getPackageKey();
+        $aggregateShortClassName = (new ClassReflection($aggregateClassName))->getShortName();
+        return $packageKey . ':' . $aggregateShortClassName . ':' . $aggregateIdentifier;
+    }
+}

--- a/Classes/EventStore/StreamNameResolver.php
+++ b/Classes/EventStore/StreamNameResolver.php
@@ -22,7 +22,7 @@ use TYPO3\Flow\Utility\TypeHandling;
  *
  * @Flow\Scope("singleton")
  */
-class EventStreamResolver
+class StreamNameResolver
 {
     /**
      * @var PackageManagerInterface


### PR DESCRIPTION
Previously the stream name had the format
`<AggregateClassName>::<AggregateIdentifier>` hard-coding the fully qualified
class name into the persisted stream.
With this change the stream name format is changed to:
`<BoundedContext>:<ShortAggregateClassName>:<AggregateIdentifier>` (lowercased)

Where "BoundedContext" defaults to the Package Key of the aggregate.
Example:
`Some.PackageKey:SomeAggregate:<UUID>`

Furthermore this changes the persisted event type from
`<EventClassName>`
to
`<BoundedContext>:<ShortEventType>`.

This is also the first step to allow 3rd party code to hook into the mapping
i.e. in order to up-cast event types.

Related: #36