### PR TITLE
TASK: Use the event class name to resolve listener

### DIFF
--- a/Classes/Domain/AbstractAggregateRoot.php
+++ b/Classes/Domain/AbstractAggregateRoot.php
@@ -14,7 +14,6 @@ namespace Neos\Cqrs\Domain;
 use Neos\Cqrs\Event\AggregateEventInterface;
 use Neos\Cqrs\Event\EventInterface;
 use Neos\Cqrs\Event\EventTransport;
-use Neos\Cqrs\Event\EventTypeResolver;
 use Neos\Cqrs\Message\MessageMetadata;
 use TYPO3\Flow\Annotations as Flow;
 
@@ -23,11 +22,6 @@ use TYPO3\Flow\Annotations as Flow;
  */
 abstract class AbstractAggregateRoot implements AggregateRootInterface
 {
-    /**
-     * @var EventTypeResolver
-     * @Flow\Inject
-     */
-    protected $eventTypeService;
 
     /**
      * @var string
@@ -110,7 +104,7 @@ abstract class AbstractAggregateRoot implements AggregateRootInterface
      */
     final protected function apply(EventInterface $event)
     {
-        $method = sprintf('when%s', $this->eventTypeService->getEventShortType($event));
+        $method = sprintf('when%s', (new \ReflectionClass($event))->getShortName());
         if (method_exists($this, $method)) {
             $this->$method($event);
         }

--- a/Classes/Domain/AbstractAggregateRoot.php
+++ b/Classes/Domain/AbstractAggregateRoot.php
@@ -104,9 +104,9 @@ abstract class AbstractAggregateRoot implements AggregateRootInterface
      */
     final protected function apply(EventInterface $event)
     {
-        $method = sprintf('when%s', (new \ReflectionClass($event))->getShortName());
-        if (method_exists($this, $method)) {
-            $this->$method($event);
+        $methodName = sprintf('when%s', (new \ReflectionClass($event))->getShortName());
+        if (method_exists($this, $methodName)) {
+            $this->$methodName($event);
         }
     }
 }

--- a/Classes/Event/EventTypeResolver.php
+++ b/Classes/Event/EventTypeResolver.php
@@ -121,20 +121,20 @@ class EventTypeResolver
      */
     public static function eventTypeMapping(ObjectManagerInterface $objectManager)
     {
-        $buildEventType = function ($eventClassname) {
-            list($vendor, $package) = explode('\\', $eventClassname);
-            $eventName = substr($eventClassname, strrpos($eventClassname, '\\') + 1);
-            return $vendor . ':' . $package . ':' . $eventName;
+        $buildEventType = function($eventClassName) use ($objectManager) {
+            $packageKey = $objectManager->getPackageKeyByObjectName($eventClassName);
+            $shortEventClassName = (new \ReflectionClass($eventClassName))->getShortName();
+            return $packageKey . ':' . $shortEventClassName;
         };
         $mapping = [];
         /** @var ReflectionService $reflectionService */
         $reflectionService = $objectManager->get(ReflectionService::class);
-        foreach ($reflectionService->getAllImplementationClassNamesForInterface(EventInterface::class) as $eventClassname) {
-            $type = $buildEventType($eventClassname);
+        foreach ($reflectionService->getAllImplementationClassNamesForInterface(EventInterface::class) as $eventClassName) {
+            $type = $buildEventType($eventClassName);
             if (in_array($type, $mapping)) {
                 throw new Exception(sprintf('Duplicate event type "%s"', $type), 1474710799);
             }
-            $mapping[$eventClassname] = $buildEventType($eventClassname);
+            $mapping[$eventClassName] = $buildEventType($eventClassName);
         }
         return $mapping;
     }

--- a/Classes/EventListener/EventListenerLocator.php
+++ b/Classes/EventListener/EventListenerLocator.php
@@ -98,19 +98,19 @@ class EventListenerLocator
                 if (!$reflectionService->isClassImplementationOf($eventClassName, EventInterface::class)) {
                     throw new Exception(sprintf('Invalid listener in %s::%s the method signature is wrong, the first parameter should be cast to an implementation of EventInterface', $listenerClassName, $methodName), 1472504443);
                 }
-                $eventType = $eventTypeResolver->getEventTypeByClassName($eventClassName);
+
                 if (isset($parameters[1])) {
                     $metaDataType = $parameters[1]['class'];
                     if ($metaDataType !== MessageMetadata::class) {
                         throw new Exception(sprintf('Invalid listener in %s::%s the method signature is wrong, the second parameter should be cast to MessageMetaData', $listenerClassName, $methodName), 1472504303);
                     }
                 }
-                $eventShortName = $eventTypeResolver->getEventShortTypeByClassName($eventClassName);
-                $expectedMethodName = 'when' . $eventShortName;
+                $expectedMethodName = 'when' . (new \ReflectionClass($eventClassName))->getShortName();
                 if ($expectedMethodName !== $methodName) {
                     throw new Exception(sprintf('Invalid listener in %s::%s the method name is expected to be "%s"', $listenerClassName, $methodName, $expectedMethodName), 1476442394);
                 }
 
+                $eventType = $eventTypeResolver->getEventTypeByClassName($eventClassName);
                 if (!isset($listeners[$eventType])) {
                     $listeners[$eventType] = [];
                 }


### PR DESCRIPTION
Previously the "event type" was used to resolve the `when*()` method names
of event listeners.
Currently the event type is equal to the short event class name, but this
had some drawbacks:

* We need an instance of the `EventTypeResolver` in the aggregate
* It wasn't possible to map an event type to a different method

This commit also fixes the package key prefixing!

Resolves: #63