### PR TITLE
BUGFIX: Fix signature of `RepositoryInterface`

### DIFF
--- a/Classes/Domain/RepositoryInterface.php
+++ b/Classes/Domain/RepositoryInterface.php
@@ -23,8 +23,8 @@ interface RepositoryInterface
     public function findByIdentifier($identifier);
 
     /**
-     * @param AggregateRootInterface $aggregate
+     * @param EventSourcedAggregateRootInterface $aggregate
      * @return void
      */
-    public function save(AggregateRootInterface $aggregate);
+    public function save(EventSourcedAggregateRootInterface $aggregate);
 }

--- a/Classes/EventStore/EventSourcedRepository.php
+++ b/Classes/EventStore/EventSourcedRepository.php
@@ -84,10 +84,10 @@ abstract class EventSourcedRepository implements RepositoryInterface
     }
 
     /**
-     * @param  AggregateRootInterface $aggregate
+     * @param  EventSourcedAggregateRootInterface $aggregate
      * @return void
      */
-    public function save(AggregateRootInterface $aggregate)
+    public function save(EventSourcedAggregateRootInterface $aggregate)
     {
         $streamName = $this->streamNameResolver->getStreamNameForAggregate($aggregate);
         try {


### PR DESCRIPTION
The `Repository` can only be used for `EventSourcedAggregateRootInterface`
instances.
This change adjusts the signature respectively.