### PR TITLE
TASK: Static factory method for aggregate roots

### DIFF
--- a/Classes/Domain/AbstractAggregateRoot.php
+++ b/Classes/Domain/AbstractAggregateRoot.php
@@ -95,14 +95,6 @@ abstract class AbstractAggregateRoot implements AggregateRootInterface
     }
 
     /**
-     * @return array
-     */
-    final protected function getEvents(): array
-    {
-        return $this->events;
-    }
-
-    /**
      * Apply the given event to this aggregate root.
      *
      * @param  EventInterface $event

--- a/Classes/Domain/AbstractEventSourcedAggregateRoot.php
+++ b/Classes/Domain/AbstractEventSourcedAggregateRoot.php
@@ -16,23 +16,22 @@ use Neos\Cqrs\EventStore\EventStream;
 use Neos\Cqrs\RuntimeException;
 
 /**
- * AggregateRootTrait
+ * Base implementation for an event-sourced aggregate root
  */
 abstract class AbstractEventSourcedAggregateRoot extends AbstractAggregateRoot implements EventSourcedAggregateRootInterface
 {
     /**
+     * @param string $identifier
      * @param EventStream $stream
-     * @throws RuntimeException
+     * @return self
      */
-    public function reconstituteFromEventStream(EventStream $stream)
+    public static function reconstituteFromEventStream(string $identifier, EventStream $stream)
     {
-        if ($this->getEvents() !== []) {
-            throw new RuntimeException(sprintf('%s has already been reconstituted from the event stream.', get_class($this)), 1474547708762);
-        }
-
+        $instance = new static($identifier);
         /** @var EventTransport $eventTransport */
         foreach ($stream as $eventTransport) {
-            $this->apply($eventTransport->getEvent());
+            $instance->apply($eventTransport->getEvent());
         }
+        return $instance;
     }
 }

--- a/Classes/Domain/EventSourcedAggregateRootInterface.php
+++ b/Classes/Domain/EventSourcedAggregateRootInterface.php
@@ -19,8 +19,9 @@ use Neos\Cqrs\EventStore\EventStream;
 interface EventSourcedAggregateRootInterface extends AggregateRootInterface
 {
     /**
+     * @param string $identifier
      * @param EventStream $stream
-     * @return void
+     * @return self
      */
-    public function reconstituteFromEventStream(EventStream $stream);
+    public static function reconstituteFromEventStream(string $identifier, EventStream $stream);
 }

--- a/Classes/EventStore/EventSourcedRepository.php
+++ b/Classes/EventStore/EventSourcedRepository.php
@@ -74,13 +74,10 @@ abstract class EventSourcedRepository implements RepositoryInterface
         if (!class_exists($this->aggregateClassName)) {
             throw new AggregateRootNotFoundException(sprintf("Could not reconstitute the aggregate root %s because its class '%s' does not exist.", $identifier, $this->aggregateClassName), 1474454928115);
         }
-
-        $aggregateRoot = unserialize('O:' . strlen($this->aggregateClassName) . ':"' . $this->aggregateClassName . '":1:{s:13:"' . chr(0) . '*' . chr(0) . 'identifier";s:36:"' . $identifier . '";}');
-        if (!$aggregateRoot instanceof EventSourcedAggregateRootInterface) {
+        if (!is_subclass_of($this->aggregateClassName, EventSourcedAggregateRootInterface::class)) {
             throw new AggregateRootNotFoundException(sprintf("Could not reconstitute the aggregate root '%s' with id '%s' because it does not implement the EventSourcedAggregateRootInterface.", $this->aggregateClassName, $identifier, $this->aggregateClassName), 1474464335530);
         }
-        $aggregateRoot->reconstituteFromEventStream($eventStream);
-        return $aggregateRoot;
+        return call_user_func($this->aggregateClassName . '::reconstituteFromEventStream', $identifier, $eventStream);
     }
 
     /**


### PR DESCRIPTION
This turns `AggregateRoot::reconstituteFromEventStream()` into a static
factory method that class the protected constructor.

This way we can ommit the `unserialize()` trick and ensure consistency.

Resolves: #67