### PR TITLE
!!! FEATURE: Drop projection data before replay

### DIFF
--- a/Classes/Projection/Doctrine/AbstractDoctrineProjector.php
+++ b/Classes/Projection/Doctrine/AbstractDoctrineProjector.php
@@ -105,7 +105,7 @@ abstract class AbstractDoctrineProjector extends AbstractBaseProjector
      * @return void
      * @api
      */
-   public function drop()
+   public function reset()
    {
        $this->projectionPersistenceManager->drop($this->getReadModelClassName());
    }

--- a/Classes/Projection/Doctrine/AbstractDoctrineProjector.php
+++ b/Classes/Projection/Doctrine/AbstractDoctrineProjector.php
@@ -105,8 +105,8 @@ abstract class AbstractDoctrineProjector extends AbstractBaseProjector
      * @return void
      * @api
      */
-    protected function drop()
-    {
-        $this->projectionPersistenceManager->drop($this->getReadModelClassName());
-    }
+   public function drop()
+   {
+       $this->projectionPersistenceManager->drop($this->getReadModelClassName());
+   }
 }

--- a/Classes/Projection/ProjectionManager.php
+++ b/Classes/Projection/ProjectionManager.php
@@ -91,7 +91,7 @@ class ProjectionManager
      * Replay events of the specified projection
      *
      * @param string $projectionIdentifier
-     * @return integer Number of events which have been replayed
+     * @return int Number of events which have been replayed
      */
     public function replay(string $projectionIdentifier)
     {

--- a/Classes/Projection/ProjectionManager.php
+++ b/Classes/Projection/ProjectionManager.php
@@ -97,6 +97,12 @@ class ProjectionManager
     {
         $eventCount = 0;
         $projection = $this->getProjection($projectionIdentifier);
+
+        $projector = $this->objectManager->get($projection->getProjectorClassName());
+        if ($projector instanceof ProjectorInterface) {
+            $projector->drop();
+        }
+
         $filter = new EventTypesFilter($projection->getEventTypes());
 
         foreach ($this->eventStore->get($filter) as $index => $eventWithMetadata) {

--- a/Classes/Projection/ProjectionManager.php
+++ b/Classes/Projection/ProjectionManager.php
@@ -99,9 +99,7 @@ class ProjectionManager
         $projection = $this->getProjection($projectionIdentifier);
 
         $projector = $this->objectManager->get($projection->getProjectorClassName());
-        if ($projector instanceof ProjectorInterface) {
-            $projector->drop();
-        }
+        $projector->reset();
 
         $filter = new EventTypesFilter($projection->getEventTypes());
 

--- a/Classes/Projection/ProjectorInterface.php
+++ b/Classes/Projection/ProjectorInterface.php
@@ -33,5 +33,5 @@ interface ProjectorInterface extends EventListenerInterface
      * @return void
      * @api
      */
-    public function drop();
+    public function reset();
 }

--- a/Classes/Projection/ProjectorInterface.php
+++ b/Classes/Projection/ProjectorInterface.php
@@ -22,6 +22,16 @@ interface ProjectorInterface extends EventListenerInterface
      * Returns the class name of the (main) Read Model of the concrete projector
      *
      * @return string
+     * @api
      */
     public function getReadModelClassName(): string;
+
+    /**
+     * Removes all objects of this repository as if remove() was called for all of them.
+     * For usage in the concrete projector.
+     *
+     * @return void
+     * @api
+     */
+    public function drop();
 }


### PR DESCRIPTION
Before replaying events for a projection, the projection data
is now dropped.

This introduces a new method `reset()` to the `ProjectorInterface`.

Closes #81