### PR TITLE
Feature: Asynchronous events

### DIFF
--- a/Classes/Command/ProjectionCommandController.php
+++ b/Classes/Command/ProjectionCommandController.php
@@ -160,11 +160,11 @@ class ProjectionCommandController extends CommandController
      * @see neos.cqrs:projection:list
      * @see neos.cqrs:projection:replay
      */
-    public function catchupCommand($projection)
+    public function catchUpCommand($projection)
     {
         try {
             $this->outputLine('Catching up projection "%s" ...', [$projection]);
-            $eventsCount = $this->projectionManager->catchup($projection);
+            $eventsCount = $this->projectionManager->catchUp($projection);
             $this->outputLine('Applied %d events.', [$eventsCount]);
         } catch (\Exception $e) {
             $this->outputLine('<error>%s</error>', [$e->getMessage()]);

--- a/Classes/Command/ProjectionCommandController.php
+++ b/Classes/Command/ProjectionCommandController.php
@@ -143,7 +143,29 @@ class ProjectionCommandController extends CommandController
                     $eventsCount += $this->projectionManager->replay($projection->getIdentifier());
                 }
             }
-            $this->outputLine('Replayed %s events.', [$eventsCount]);
+            $this->outputLine('Replayed %d events.', [$eventsCount]);
+        } catch (\Exception $e) {
+            $this->outputLine('<error>%s</error>', [$e->getMessage()]);
+            $this->quit(1);
+        }
+    }
+
+    /**
+     * Forward new events to a projection
+     *
+     * This command allows you to play all relevant unseen events for one specific projection.
+     *
+     * @param string $projection The projection identifier; see projection:list for possible options
+     * @return void
+     * @see neos.cqrs:projection:list
+     * @see neos.cqrs:projection:replay
+     */
+    public function catchupCommand($projection)
+    {
+        try {
+            $this->outputLine('Catching up projection "%s" ...', [$projection]);
+            $eventsCount = $this->projectionManager->catchup($projection);
+            $this->outputLine('Applied %d events.', [$eventsCount]);
         } catch (\Exception $e) {
             $this->outputLine('<error>%s</error>', [$e->getMessage()]);
             $this->quit(1);

--- a/Classes/Event/EventPublisher.php
+++ b/Classes/Event/EventPublisher.php
@@ -103,7 +103,7 @@ class EventPublisher
         foreach ($rawEvents as $rawEvent) {
             $eventClassName = $this->eventTypeResolver->getEventClassNameByType($rawEvent->getType());
             $event = $this->propertyMapper->convert($rawEvent->getPayload(), $eventClassName, $configuration);
-            foreach ($this->eventListenerLocator->getListeners($rawEvent->getType()) as $listener) {
+            foreach ($this->eventListenerLocator->getSynchronousListeners($rawEvent->getType()) as $listener) {
                 call_user_func($listener, $event, $rawEvent);
             }
         }

--- a/Classes/EventListener/AsyncEventListenerInterface.php
+++ b/Classes/EventListener/AsyncEventListenerInterface.php
@@ -1,0 +1,19 @@
+<?php
+namespace Neos\Cqrs\EventListener;
+
+/*
+ * This file is part of the Neos.Cqrs package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Marker interface for asynchronous event listeners
+ */
+interface AsyncEventListenerInterface extends EventListenerInterface
+{
+}

--- a/Classes/EventListener/AsynchronousEventListenerInterface.php
+++ b/Classes/EventListener/AsynchronousEventListenerInterface.php
@@ -13,7 +13,9 @@ namespace Neos\Cqrs\EventListener;
 
 /**
  * Marker interface for asynchronous event listeners
+ *
+ * Asynchronous event listeners are not triggered directly when new events are published, but only when executing the CLI command projection:catchup
  */
-interface AsyncEventListenerInterface extends EventListenerInterface
+interface AsynchronousEventListenerInterface extends EventListenerInterface
 {
 }

--- a/Classes/EventListener/EventListenerLocator.php
+++ b/Classes/EventListener/EventListenerLocator.php
@@ -79,6 +79,32 @@ class EventListenerLocator
     }
 
     /**
+     * Returns synchronous event listeners for the given event type
+     *
+     * @param string $eventType
+     * @return \callable[]
+     */
+    public function getSynchronousListeners(string $eventType): array
+    {
+        return array_filter($this->getListeners($eventType), function(array $listener) {
+            return (!$listener[0] instanceof AsyncEventListenerInterface);
+        });
+    }
+
+    /**
+     * Returns asynchronous event listeners (implementing AsyncEventListenerInterface) for the given event type
+     *
+     * @param string $eventType
+     * @return \callable[]
+     */
+    public function getAsynchronousListeners(string $eventType): array
+    {
+        return array_filter($this->getListeners($eventType), function(array $listener) {
+            return ($listener[0] instanceof AsyncEventListenerInterface);
+        });
+    }
+
+    /**
      * Returns a single listener for the given $eventType and $listenerClassName, or null if the given listener
      * does not handle events of the specified type.
      *

--- a/Classes/EventListener/EventListenerLocator.php
+++ b/Classes/EventListener/EventListenerLocator.php
@@ -86,8 +86,8 @@ class EventListenerLocator
      */
     public function getSynchronousListeners(string $eventType): array
     {
-        return array_filter($this->getListeners($eventType), function(array $listener) {
-            return (!$listener[0] instanceof AsyncEventListenerInterface);
+        return array_filter($this->getListeners($eventType), function (array $listener) {
+            return (!$listener[0] instanceof AsynchronousEventListenerInterface);
         });
     }
 
@@ -99,8 +99,8 @@ class EventListenerLocator
      */
     public function getAsynchronousListeners(string $eventType): array
     {
-        return array_filter($this->getListeners($eventType), function(array $listener) {
-            return ($listener[0] instanceof AsyncEventListenerInterface);
+        return array_filter($this->getListeners($eventType), function (array $listener) {
+            return ($listener[0] instanceof AsynchronousEventListenerInterface);
         });
     }
 

--- a/Classes/EventStore/EventStreamFilterInterface.php
+++ b/Classes/EventStore/EventStreamFilterInterface.php
@@ -29,4 +29,8 @@ interface EventStreamFilterInterface
     public function getEventTypes(): array;
 
     public function hasEventTypes(): bool;
+
+    public function getMinimumSequenceNumber(): int;
+
+    public function hasMinimumSequenceNumber(): bool;
 }

--- a/Classes/EventStore/EventTypesFilter.php
+++ b/Classes/EventStore/EventTypesFilter.php
@@ -21,12 +21,18 @@ class EventTypesFilter implements EventStreamFilterInterface
      */
     private $eventTypes;
 
-    public function __construct(array $eventTypes)
+    /**
+     * @var int
+     */
+    private $minimumSequenceNumber = 0;
+
+    public function __construct(array $eventTypes, int $minimumSequenceNumber = 0)
     {
         if ($eventTypes === []) {
             throw new Exception('No type filter provided', 1478299912);
         }
         $this->eventTypes = $eventTypes;
+        $this->minimumSequenceNumber = $minimumSequenceNumber;
     }
 
     public function getStreamName(): string
@@ -60,5 +66,15 @@ class EventTypesFilter implements EventStreamFilterInterface
     public function hasEventTypes(): bool
     {
         return true;
+    }
+
+    public function getMinimumSequenceNumber(): int
+    {
+        return $this->minimumSequenceNumber;
+    }
+
+    public function hasMinimumSequenceNumber(): bool
+    {
+        return $this->minimumSequenceNumber > 0;
     }
 }

--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -165,5 +165,9 @@ class DoctrineEventStorage implements EventStorageInterface
             $query->andWhere('type IN (:eventTypes)');
             $query->setParameter('eventTypes', $filter->getEventTypes(), Connection::PARAM_STR_ARRAY);
         }
+        if ($filter->hasMinimumSequenceNumber()) {
+            $query->andWhere('id >= :minimumSequenceNumber');
+            $query->setParameter('minimumSequenceNumber', $filter->getMinimumSequenceNumber());
+        }
     }
 }

--- a/Classes/EventStore/StreamNameFilter.php
+++ b/Classes/EventStore/StreamNameFilter.php
@@ -62,4 +62,14 @@ class StreamNameFilter implements EventStreamFilterInterface
     {
         return false;
     }
+
+    public function getMinimumSequenceNumber(): int
+    {
+        return 0;
+    }
+
+    public function hasMinimumSequenceNumber(): bool
+    {
+        return false;
+    }
 }

--- a/Classes/Projection/ProjectionManager.php
+++ b/Classes/Projection/ProjectionManager.php
@@ -149,7 +149,7 @@ class ProjectionManager
      * @param string $projectionIdentifier
      * @return int Number of events which have been applied
      */
-    public function catchup(string $projectionIdentifier): int
+    public function catchUp(string $projectionIdentifier): int
     {
         $fullProjectionIdentifier = $this->normalizeProjectionIdentifier($projectionIdentifier);
         $cacheId = md5($fullProjectionIdentifier);


### PR DESCRIPTION
Usage:
In your projector implement the new AsynchronousEventListenerInterface for example:

class SomeProjector extends AbstractDoctrineProjector implements AsynchronousEventListenerInterface
{
...
}
Now this projector will be skipped during default event publishing and you can trigger a manual catchup via

flow projection:catchup

Handling of "generic" async `EventListeners` will be tackled in a separate pull request