### PR TITLE
!!! TASK: Rename AbstractEventSourcedRepository->findByIdentifier()

### DIFF
--- a/Classes/Domain/RepositoryInterface.php
+++ b/Classes/Domain/RepositoryInterface.php
@@ -20,7 +20,7 @@ interface RepositoryInterface
      * @param string $identifier
      * @return AggregateRootInterface|null
      */
-    public function findByIdentifier($identifier);
+    public function get(string $identifier);
 
     /**
      * @param EventSourcedAggregateRootInterface $aggregate


### PR DESCRIPTION
This change renames `findByIdentifier()` to `get()`.

Closes #80