### PR TITLE
BUGFIX: Don't catch all exceptions in projection CLI

### DIFF
--- a/Classes/Command/ProjectionCommandController.php
+++ b/Classes/Command/ProjectionCommandController.php
@@ -11,6 +11,7 @@ namespace Neos\Cqrs\Command;
  * source code.
  */
 
+use Neos\Cqrs\Projection\InvalidProjectionIdentifierException;
 use Neos\Cqrs\Projection\Projection;
 use Neos\Cqrs\Projection\ProjectionManager;
 use TYPO3\Flow\Annotations as Flow;
@@ -77,7 +78,7 @@ class ProjectionCommandController extends CommandController
      */
     public function describeCommand($projection)
     {
-        $projectionDto = $this->getProjection($projection);
+        $projectionDto = $this->resolveProjectionOrQuit($projection);
 
         $this->outputLine('<b>PROJECTION:</b>');
         $this->outputLine('  <i>%s</i>', [$projectionDto->getIdentifier()]);
@@ -107,7 +108,7 @@ class ProjectionCommandController extends CommandController
      */
     public function replayCommand($projection)
     {
-        $projectionDto = $this->getProjection($projection);
+        $projectionDto = $this->resolveProjectionOrQuit($projection);
 
         $this->outputLine('Replaying events for projection "%s" ...', [$projectionDto->getIdentifier()]);
         $eventsCount = $this->projectionManager->replay($projectionDto->getIdentifier());
@@ -150,7 +151,7 @@ class ProjectionCommandController extends CommandController
      */
     public function catchUpCommand($projection)
     {
-        $projectionDto = $this->getProjection($projection);
+        $projectionDto = $this->resolveProjectionOrQuit($projection);
 
         $this->outputLine('Catching up projection "%s" ...', [$projectionDto->getIdentifier()]);
         $eventsCount = $this->projectionManager->catchUp($projectionDto->getIdentifier());
@@ -205,11 +206,11 @@ class ProjectionCommandController extends CommandController
      * @param string $projectionIdentifier
      * @return Projection
      */
-    private function getProjection($projectionIdentifier): Projection
+    private function resolveProjectionOrQuit($projectionIdentifier): Projection
     {
         try {
             return $this->projectionManager->getProjection($projectionIdentifier);
-        } catch (\InvalidArgumentException $exception) {
+        } catch (InvalidProjectionIdentifierException $exception) {
             $this->outputLine('<error>%s</error>', [$exception->getMessage()]);
             $this->quit(1);
         }

--- a/Classes/Projection/InvalidProjectionIdentifierException.php
+++ b/Classes/Projection/InvalidProjectionIdentifierException.php
@@ -1,0 +1,22 @@
+<?php
+namespace Neos\Cqrs\Projection;
+
+/*
+ * This file is part of the Neos.Cqrs package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Cqrs\Exception;
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * An invalid projection identifier exception (thrown if the given identifier does not exist or is ambiguous)
+ */
+class InvalidProjectionIdentifierException extends Exception
+{
+}

--- a/Classes/Projection/ProjectionManager.php
+++ b/Classes/Projection/ProjectionManager.php
@@ -190,7 +190,7 @@ class ProjectionManager
      *
      * @param string $projectionIdentifier in the form "<package.key>:<projection>", "<key>:<projection>" or "<projection">"
      * @return string
-     * @throws \InvalidArgumentException if no matching projector could be found
+     * @throws InvalidProjectionIdentifierException if no matching projector could be found
      */
     private function normalizeProjectionIdentifier($projectionIdentifier)
     {
@@ -201,10 +201,10 @@ class ProjectionManager
             }
         }
         if ($matchingIdentifiers === []) {
-            throw new \InvalidArgumentException(sprintf('No projection could be found that matches the projection identifier "%s"', $projectionIdentifier), 1476368605);
+            throw new InvalidProjectionIdentifierException(sprintf('No projection could be found that matches the projection identifier "%s"', $projectionIdentifier), 1476368605);
         }
         if (count($matchingIdentifiers) !== 1) {
-            throw new \InvalidArgumentException(sprintf('More than one projection matches the projection identifier "%s":%s%s', $projectionIdentifier, chr(10), implode(', ', $matchingIdentifiers)), 1476368615);
+            throw new InvalidProjectionIdentifierException(sprintf('More than one projection matches the projection identifier "%s":%s%s', $projectionIdentifier, chr(10), implode(', ', $matchingIdentifiers)), 1476368615);
         }
         return $matchingIdentifiers[0];
     }
@@ -216,7 +216,7 @@ class ProjectionManager
      * @param string $shortIdentifier
      * @param string $fullIdentifier The full projection identifier
      * @return bool
-     * @throws \InvalidArgumentException if the given $shortIdentifier is not in the valid form
+     * @throws InvalidProjectionIdentifierException if the given $shortIdentifier is not in the valid form
      * @see normalizeProjectionIdentifier()
      */
     private function projectionIdentifiersMatch(string $shortIdentifier, string $fullIdentifier): bool
@@ -233,7 +233,7 @@ class ProjectionManager
             return $shortIdentifier === $fullIdentifierParts[1];
         }
         if ($shortIdentifierPartsCount !== 2) {
-            throw new \InvalidArgumentException(sprintf('Invalid projection identifier "%s", identifiers must have the format "<projection>" or "<package-key>:<projection>".', $shortIdentifier), 1476367741);
+            throw new InvalidProjectionIdentifierException(sprintf('Invalid projection identifier "%s", identifiers must have the format "<projection>" or "<package-key>:<projection>".', $shortIdentifier), 1476367741);
         }
         return
             $shortIdentifierParts[1] === $fullIdentifierParts[1]


### PR DESCRIPTION
a `try/catch` block catching any `\Exception` is dangerous because
it disables exception logging and can disguise nested exceptions.