### PR TITLE
BUGFIX: Don't fetch all events at once

### DIFF
--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -75,7 +75,7 @@ class DoctrineEventStorage implements EventStorageInterface
             ->orderBy('id', 'ASC');
         $this->applyEventStreamFilter($query, $filter);
 
-        $streamIterator = new DoctrineStreamIterator($query->execute());
+        $streamIterator = new DoctrineStreamIterator($query);
         return new EventStream($streamIterator, $this->getStreamVersion($filter));
     }
 

--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -167,7 +167,7 @@ class DoctrineEventStorage implements EventStorageInterface
             $query->setParameter('eventTypes', $filter->getEventTypes(), Connection::PARAM_STR_ARRAY);
         }
         if ($filter->hasMinimumSequenceNumber()) {
-            $query->andWhere('id >= :minimumSequenceNumber');
+            $query->andWhere('sequencenumber >= :minimumSequenceNumber');
             $query->setParameter('minimumSequenceNumber', $filter->getMinimumSequenceNumber());
         }
     }

--- a/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
@@ -62,12 +62,12 @@ final class DoctrineStreamIterator implements \Iterator
         $metadata = json_decode($currentEventData['metadata'], true);
         $recordedAt = new \DateTimeImmutable($currentEventData['recordedat']);
         return new RawEvent(
-            $currentEventData['id'],
+            $currentEventData['sequencenumber'],
             $currentEventData['type'],
             $payload,
             $metadata,
             (int)$currentEventData['version'],
-            $this->currentEventData['id'],
+            $currentEventData['id'],
             $recordedAt
         );
     }
@@ -90,7 +90,7 @@ final class DoctrineStreamIterator implements \Iterator
      */
     public function key()
     {
-        return $this->innerIterator->valid() ? $this->innerIterator->current()['id'] : null;
+        return $this->innerIterator->valid() ? $this->innerIterator->current()['sequencenumber'] : null;
     }
 
     /**

--- a/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
@@ -12,6 +12,7 @@ namespace Neos\Cqrs\EventStore\Storage\Doctrine;
  */
 
 use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Query\QueryBuilder;
 use Neos\Cqrs\EventStore\RawEvent;
 
 /**
@@ -21,27 +22,39 @@ final class DoctrineStreamIterator implements \Iterator
 {
 
     /**
-     * @var Statement
+     * The number of records to fetch per batch
+     *
+     * @var int
      */
-    private $statement;
+    const BATCH_SIZE = 100;
 
     /**
-     * @var array|false
+     * @var QueryBuilder
      */
-    private $currentEventData;
+    private $queryBuilder;
 
     /**
      * @var int
      */
-    private $currentId;
+    private $currentOffset = 0;
 
     /**
-     * @param Statement $statement
+     * @var \ArrayIterator
      */
-    public function __construct(Statement $statement)
-    {
-        $this->statement = $statement;
+    private $innerIterator;
 
+    /**
+     * @var bool
+     */
+    private $rewound = false;
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     */
+    public function __construct(QueryBuilder $queryBuilder)
+    {
+        $this->queryBuilder = clone $queryBuilder;
+        $this->queryBuilder->setMaxResults(self::BATCH_SIZE);
         $this->rewind();
     }
 
@@ -50,18 +63,16 @@ final class DoctrineStreamIterator implements \Iterator
      */
     public function current()
     {
-        if ($this->currentEventData === false) {
-            return null;
-        }
-        $payload = json_decode($this->currentEventData['payload'], true);
-        $metadata = json_decode($this->currentEventData['metadata'], true);
-        $recordedAt = new \DateTimeImmutable($this->currentEventData['recordedat']);
+        $currentEventData = $this->innerIterator->current();
+        $payload = json_decode($currentEventData['payload'], true);
+        $metadata = json_decode($currentEventData['metadata'], true);
+        $recordedAt = new \DateTimeImmutable($currentEventData['recordedat']);
         return new RawEvent(
-            $this->currentEventData['id'],
-            $this->currentEventData['type'],
+            $currentEventData['id'],
+            $currentEventData['type'],
             $payload,
             $metadata,
-            (int)$this->currentEventData['version'],
+            (int)$currentEventData['version'],
             $recordedAt
         );
     }
@@ -71,13 +82,11 @@ final class DoctrineStreamIterator implements \Iterator
      */
     public function next()
     {
-        $this->currentEventData = $this->statement->fetch();
-
-        if ($this->currentEventData !== false) {
-            $this->currentId = (integer)$this->currentEventData['id'];
-        } else {
-            $this->currentId = -1;
+        $this->innerIterator->next();
+        if ($this->innerIterator->valid()) {
+            return;
         }
+        $this->fetchBatch();
     }
 
     /**
@@ -85,11 +94,7 @@ final class DoctrineStreamIterator implements \Iterator
      */
     public function key()
     {
-        if ($this->currentId === -1) {
-            return false;
-        }
-
-        return $this->currentId;
+        return $this->innerIterator->current()['id'];
     }
 
     /**
@@ -97,7 +102,7 @@ final class DoctrineStreamIterator implements \Iterator
      */
     public function valid()
     {
-        return $this->currentEventData !== false;
+        return $this->innerIterator->valid();
     }
 
     /**
@@ -105,15 +110,23 @@ final class DoctrineStreamIterator implements \Iterator
      */
     public function rewind()
     {
-        //Only perform rewind if current item is not the first element
-        if ($this->currentId === 0) {
+        if ($this->rewound) {
             return;
         }
-        $this->statement->execute();
+        $this->fetchBatch();
+        $this->rewound = true;
+    }
 
-        $this->currentEventData = null;
-        $this->currentId = -1;
-
-        $this->next();
+    /**
+     * Fetches a batch of maximum BATCH_SIZE records
+     *
+     * @return void
+     */
+    private function fetchBatch()
+    {
+        $this->queryBuilder->setFirstResult($this->currentOffset);
+        $rawResult = $this->queryBuilder->execute()->fetchAll();
+        $this->currentOffset += count($rawResult);
+        $this->innerIterator = new \ArrayIterator($rawResult);
     }
 }

--- a/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
@@ -11,7 +11,6 @@ namespace Neos\Cqrs\EventStore\Storage\Doctrine;
  * source code.
  */
 
-use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Neos\Cqrs\EventStore\RawEvent;
 


### PR DESCRIPTION
This adjusts the `DoctrineStreamIterator` so that it always fetches
at most 100 events at once from the database.

Background:

`QueryBuilder::execute()` behaves differently than it's `\PDO` counter
part in that it always fetches the whole result set immediately.
For projections with lots of events this will exceed the memory limit.

Fixes: #96