### PR TITLE
BUGFIX: Don't store "version" in the EventStream

### DIFF
--- a/Classes/Domain/AbstractEventSourcedAggregateRoot.php
+++ b/Classes/Domain/AbstractEventSourcedAggregateRoot.php
@@ -42,10 +42,12 @@ abstract class AbstractEventSourcedAggregateRoot extends AbstractAggregateRoot i
     public static function reconstituteFromEventStream(string $identifier, EventStream $stream)
     {
         $instance = new static($identifier);
+        $lastAppliedEventVersion = -1;
         foreach ($stream as $eventAndRawEvent) {
             $instance->apply($eventAndRawEvent->getEvent());
+            $lastAppliedEventVersion = $eventAndRawEvent->getRawEvent()->getVersion();
         }
-        $instance->reconstitutionVersion = $stream->getVersion();
+        $instance->reconstitutionVersion = $lastAppliedEventVersion;
         return $instance;
     }
 }

--- a/Classes/EventStore/EventStream.php
+++ b/Classes/EventStore/EventStream.php
@@ -39,26 +39,11 @@ final class EventStream implements \Iterator
     private $streamIterator;
 
     /**
-     * @var integer
-     */
-    protected $version;
-
-    /**
      * @param \Iterator $streamIterator
-     * @param integer $version
      */
-    public function __construct(\Iterator $streamIterator, int $version = -1)
+    public function __construct(\Iterator $streamIterator)
     {
         $this->streamIterator = $streamIterator;
-        $this->version = $version;
-    }
-
-    /**
-     * @return integer
-     */
-    public function getVersion()
-    {
-        return $this->version;
     }
 
     /**

--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -76,7 +76,7 @@ class DoctrineEventStorage implements EventStorageInterface
         $this->applyEventStreamFilter($query, $filter);
 
         $streamIterator = new DoctrineStreamIterator($query->execute());
-        return new EventStream($streamIterator, $this->getStreamVersion($filter));
+        return new EventStream($streamIterator);
     }
 
     /**


### PR DESCRIPTION
Previously the `EventStream` had a version, but this only
makes sense for aggregate streams.
For different partitioned streams (e.g. for projections or
other event listeners) this version is misleading because it
just contains the highest version within the many streams.

Note:

We could replace the version with the last *sequence number*
but currently that's not needed and without that we are still
free to implement actual streams that stay open.