### PR TITLE
!!! FEATURE: Unique event identifiers

### DIFF
--- a/Classes/Event/EventPublisher.php
+++ b/Classes/Event/EventPublisher.php
@@ -19,6 +19,7 @@ use Neos\Cqrs\EventStore\WritableEvents;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Property\PropertyMapper;
 use TYPO3\Flow\Property\PropertyMappingConfiguration;
+use TYPO3\Flow\Utility\Algorithms;
 
 /**
  * @Flow\Scope("singleton")
@@ -93,7 +94,8 @@ class EventPublisher
             $metadata = [];
             $this->emitBeforePublishingEvent($event, $metadata);
             $data = $this->propertyMapper->convert($event, 'array');
-            $convertedEvents->append(new WritableEvent($type, $data, $metadata));
+            $eventIdentifier = Algorithms::generateUUID();
+            $convertedEvents->append(new WritableEvent($eventIdentifier, $type, $data, $metadata));
         }
         $rawEvents = $this->eventStore->commit($streamName, $convertedEvents, $expectedVersion);
 

--- a/Classes/EventStore/RawEvent.php
+++ b/Classes/EventStore/RawEvent.php
@@ -46,23 +46,29 @@ final class RawEvent
     private $version;
 
     /**
+     * @var int
+     */
+    private $sequenceNumber;
+
+    /**
      * @var \DateTimeInterface
      */
     protected $recordedAt;
 
-    public function __construct(string $identifier, string $type, array $payload, array $metadata, int $version, \DateTimeInterface $recordedAt)
+    public function __construct(int $sequenceNumber, string $type, array $payload, array $metadata, int $version, string $identifier, \DateTimeInterface $recordedAt)
     {
-        $this->identifier = $identifier;
+        $this->sequenceNumber = $sequenceNumber;
         $this->type = $type;
         $this->payload = $payload;
         $this->metadata = $metadata;
         $this->version = $version;
+        $this->identifier = $identifier;
         $this->recordedAt = $recordedAt;
     }
 
-    public function getIdentifier(): string
+    public function getSequenceNumber(): int
     {
-        return $this->identifier;
+        return $this->sequenceNumber;
     }
 
     public function getType(): string
@@ -83,6 +89,11 @@ final class RawEvent
     public function getVersion(): int
     {
         return $this->version;
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
     }
 
     public function getRecordedAt(): \DateTimeInterface

--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -72,7 +72,7 @@ class DoctrineEventStorage implements EventStorageInterface
         $query = $this->connection->createQueryBuilder()
             ->select('*')
             ->from($this->connectionFactory->getStreamTableName())
-            ->orderBy('id', 'ASC');
+            ->orderBy('sequencenumber', 'ASC');
         $this->applyEventStreamFilter($query, $filter);
 
         $streamIterator = new DoctrineStreamIterator($query->execute());
@@ -97,6 +97,7 @@ class DoctrineEventStorage implements EventStorageInterface
             $this->connection->insert(
                 $this->connectionFactory->getStreamTableName(),
                 [
+                    'id' => $event->getIdentifier(),
                     'stream' => $streamName,
                     'version' => ++$actualVersion,
                     'type' => $event->getType(),
@@ -109,8 +110,8 @@ class DoctrineEventStorage implements EventStorageInterface
                     'recordedat' => Type::DATETIME,
                 ]
             );
-            $eventIdentifier = $this->connection->lastInsertId();
-            $rawEvents[] = new RawEvent($eventIdentifier, $event->getType(), $event->getData(), $event->getMetadata(), $actualVersion, $this->now);
+            $sequenceNumber = $this->connection->lastInsertId();
+            $rawEvents[] = new RawEvent($sequenceNumber, $event->getType(), $event->getData(), $event->getMetadata(), $actualVersion, $event->getIdentifier(), $this->now);
         }
         $this->connection->commit();
         return $rawEvents;

--- a/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
@@ -33,7 +33,7 @@ final class DoctrineStreamIterator implements \Iterator
     /**
      * @var int
      */
-    private $currentId;
+    private $currentSequenceNumber;
 
     /**
      * @param Statement $statement
@@ -57,11 +57,12 @@ final class DoctrineStreamIterator implements \Iterator
         $metadata = json_decode($this->currentEventData['metadata'], true);
         $recordedAt = new \DateTimeImmutable($this->currentEventData['recordedat']);
         return new RawEvent(
-            $this->currentEventData['id'],
+            (int)$this->currentEventData['sequencenumber'],
             $this->currentEventData['type'],
             $payload,
             $metadata,
             (int)$this->currentEventData['version'],
+            $this->currentEventData['id'],
             $recordedAt
         );
     }
@@ -74,9 +75,9 @@ final class DoctrineStreamIterator implements \Iterator
         $this->currentEventData = $this->statement->fetch();
 
         if ($this->currentEventData !== false) {
-            $this->currentId = (integer)$this->currentEventData['id'];
+            $this->currentSequenceNumber = (integer)$this->currentEventData['sequencenumber'];
         } else {
-            $this->currentId = -1;
+            $this->currentSequenceNumber = -1;
         }
     }
 
@@ -85,11 +86,11 @@ final class DoctrineStreamIterator implements \Iterator
      */
     public function key()
     {
-        if ($this->currentId === -1) {
+        if ($this->currentSequenceNumber === -1) {
             return false;
         }
 
-        return $this->currentId;
+        return $this->currentSequenceNumber;
     }
 
     /**
@@ -106,13 +107,13 @@ final class DoctrineStreamIterator implements \Iterator
     public function rewind()
     {
         //Only perform rewind if current item is not the first element
-        if ($this->currentId === 0) {
+        if ($this->currentSequenceNumber === 0) {
             return;
         }
         $this->statement->execute();
 
         $this->currentEventData = null;
-        $this->currentId = -1;
+        $this->currentSequenceNumber = -1;
 
         $this->next();
     }

--- a/Classes/EventStore/Storage/Doctrine/Schema/EventStoreSchema.php
+++ b/Classes/EventStore/Storage/Doctrine/Schema/EventStoreSchema.php
@@ -29,9 +29,9 @@ final class EventStoreSchema
     {
         $table = $schema->createTable($name);
 
-        // The stream id, usually in the format "<BoundedContext>:<StreamName>"
-        $table->addColumn('id', Type::INTEGER, array('autoincrement' => true));
-        // The stream id, usually in the format "<BoundedContext>:<StreamName>"
+        // The monotonic sequence number
+        $table->addColumn('sequencenumber', Type::INTEGER, array('autoincrement' => true));
+        // The stream name, usually in the format "<BoundedContext>:<StreamName>"
         $table->addColumn('stream', Type::STRING, ['length' => 255]);
         // Version of the event in the respective stream
         $table->addColumn('version', Type::BIGINT, ['unsigned' => true]);
@@ -41,11 +41,14 @@ final class EventStoreSchema
         $table->addColumn('payload', Type::TEXT);
         // The event metadata as JSON
         $table->addColumn('metadata', Type::TEXT);
+        // The unique event id, usually a UUID
+        $table->addColumn('id', Type::STRING, ['length' => 255]);
         // Timestamp of the the event publishing
         $table->addColumn('recordedat', Type::DATETIME);
 
-        $table->setPrimaryKey(['id']);
-        $table->addUniqueIndex(['stream', 'version'], 'stream_version');
+        $table->setPrimaryKey(['sequencenumber']);
+        $table->addUniqueIndex(['id'], 'id_uniq');
+        $table->addUniqueIndex(['stream', 'version'], 'stream_version_uniq');
     }
 
     /**

--- a/Classes/EventStore/WritableEvent.php
+++ b/Classes/EventStore/WritableEvent.php
@@ -16,6 +16,11 @@ final class WritableEvent
     /**
      * @var string
      */
+    private $identifier;
+
+    /**
+     * @var string
+     */
     private $type;
 
     /**
@@ -28,33 +33,30 @@ final class WritableEvent
      */
     private $metadata;
 
-    public function __construct(string $type, array $data, array $metadata)
+    public function __construct(string $identifier, string $type, array $data, array $metadata)
     {
+        $this->identifier = $identifier;
         $this->type = $type;
         $this->data = $data;
         $this->metadata = $metadata;
     }
 
-    /**
-     * @return string
-     */
-    public function getType()
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function getType(): string
     {
         return $this->type;
     }
 
-    /**
-     * @return array
-     */
-    public function getData()
+    public function getData(): array
     {
         return $this->data;
     }
 
-    /**
-     * @return array
-     */
-    public function getMetadata()
+    public function getMetadata(): array
     {
         return $this->metadata;
     }


### PR DESCRIPTION
This consistently renames "id" to "sequenceNumber" where applicable
and adds a new property "identifier" to `WritableEvent` and `RawEvent`
that will be set to a UUID during event publishing.

This allows for correlation and de-duplication of events in respective
handlers.

Note:
With this change it's not yet possible to *set* the event identifier from
the application.

Related: #6