### PR TITLE
BUGFIX: Replace calls to deprecated `getPackageByClassName()`

### DIFF
--- a/Classes/Command/ProjectionCommandController.php
+++ b/Classes/Command/ProjectionCommandController.php
@@ -16,7 +16,6 @@ use Neos\Cqrs\Projection\Projection;
 use Neos\Cqrs\Projection\ProjectionManager;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\CommandController;
-use TYPO3\Flow\Package\PackageManagerInterface;
 
 /**
  * CLI Command Controller for projection related commands
@@ -30,12 +29,6 @@ class ProjectionCommandController extends CommandController
      * @var ProjectionManager
      */
     protected $projectionManager;
-
-    /**
-     * @Flow\Inject
-     * @var PackageManagerInterface
-     */
-    protected $packageManager;
 
     /**
      * @var array in the format ['<shortIdentifier>' => '<fullIdentifier>', ...]
@@ -54,7 +47,7 @@ class ProjectionCommandController extends CommandController
     {
         $lastPackageKey = null;
         foreach ($this->projectionManager->getProjections() as $projection) {
-            $packageKey = $this->packageManager->getPackageByClassName($projection->getProjectorClassName())->getPackageKey();
+            $packageKey = $this->objectManager->getPackageKeyByObjectName($projection->getProjectorClassName());
             if ($packageKey !== $lastPackageKey) {
                 $lastPackageKey = $packageKey;
                 $this->outputLine();

--- a/Classes/EventStore/EventStreamResolver.php
+++ b/Classes/EventStore/EventStreamResolver.php
@@ -13,6 +13,7 @@ namespace Neos\Cqrs\EventStore;
 
 use Neos\Cqrs\Domain\AggregateRootInterface;
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Package\PackageManagerInterface;
 use TYPO3\Flow\Reflection\ClassReflection;
 use TYPO3\Flow\Utility\TypeHandling;
@@ -24,9 +25,9 @@ class EventStreamResolver
 {
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var ObjectManagerInterface
      */
-    protected $packageManager;
+    protected $objectManager;
 
     /**
      * @param AggregateRootInterface $aggregate
@@ -44,7 +45,7 @@ class EventStreamResolver
      */
     public function getStreamNameForAggregateTypeAndIdentifier(string $aggregateClassName, string $aggregateIdentifier)
     {
-        $packageKey = $this->packageManager->getPackageByClassName($aggregateClassName)->getPackageKey();
+        $packageKey = $this->objectManager->getPackageKeyByObjectName($aggregateClassName);
         $aggregateShortClassName = (new ClassReflection($aggregateClassName))->getShortName();
         return $packageKey . ':' . $aggregateShortClassName . ':' . $aggregateIdentifier;
     }

--- a/Classes/EventStore/StreamNameResolver.php
+++ b/Classes/EventStore/StreamNameResolver.php
@@ -13,7 +13,7 @@ namespace Neos\Cqrs\EventStore;
 
 use Neos\Cqrs\Domain\AggregateRootInterface;
 use TYPO3\Flow\Annotations as Flow;
-use TYPO3\Flow\Package\PackageManagerInterface;
+use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Reflection\ClassReflection;
 use TYPO3\Flow\Utility\TypeHandling;
 
@@ -25,16 +25,16 @@ use TYPO3\Flow\Utility\TypeHandling;
 class StreamNameResolver
 {
     /**
-     * @var PackageManagerInterface
+     * @var ObjectManagerInterface
      */
-    private $packageManager;
+    private $objectManager;
 
     /**
-     * @param PackageManagerInterface $packageManager
+     * @param ObjectManagerInterface $objectManager
      */
-    public function __construct(PackageManagerInterface $packageManager)
+    public function __construct(ObjectManagerInterface $objectManager)
     {
-        $this->packageManager = $packageManager;
+        $this->objectManager = $objectManager;
     }
 
     /**
@@ -53,7 +53,7 @@ class StreamNameResolver
      */
     public function getStreamNameForAggregateTypeAndIdentifier(string $aggregateClassName, string $aggregateIdentifier)
     {
-        $packageKey = $this->packageManager->getPackageByClassName($aggregateClassName)->getPackageKey();
+        $packageKey = $this->objectManager->getPackageKeyByObjectName($aggregateClassName);
         $aggregateShortClassName = (new ClassReflection($aggregateClassName))->getShortName();
         return $packageKey . ':' . $aggregateShortClassName . ':' . $aggregateIdentifier;
     }

--- a/Classes/Projection/ProjectionManager.php
+++ b/Classes/Projection/ProjectionManager.php
@@ -249,17 +249,14 @@ class ProjectionManager
     {
         /** @var ReflectionService $reflectionService */
         $reflectionService = $objectManager->get(ReflectionService::class);
-        /** @var PackageManagerInterface $packageManager */
-        $packageManager = $objectManager->get(PackageManagerInterface::class);
         $projections = [];
         foreach ($reflectionService->getAllImplementationClassNamesForInterface(ProjectorInterface::class) as $projectorClassName) {
-            $package = $packageManager->getPackageByClassName($projectorClassName);
             $projectionName = (new ClassReflection($projectorClassName))->getShortName();
             if (substr($projectionName, -9) === 'Projector') {
                 $projectionName = substr($projectionName, 0, -9);
             }
             $projectionName = strtolower($projectionName);
-            $packageKey = strtolower($package->getPackageKey());
+            $packageKey = strtolower($objectManager->getPackageKeyByObjectName($projectorClassName));
             $projectionIdentifier = $packageKey . ':' . $projectionName;
             if (isset($projections[$projectionIdentifier])) {
                 throw new \RuntimeException(sprintf('The projection identifier "%s" is ambiguous, please rename one of the classes "%s" or "%s"', $projectionIdentifier, $projections[$projectionIdentifier], $projectorClassName), 1476198478);


### PR DESCRIPTION
The Package Manager's method `getPackageByClassName()` is deprecated
and will be removed in Flow 4.0.

This change replaces some calls to this deprecated method.

Fixes: #86