### PR TITLE
FEATURE: Custom event type identifier mapping

### DIFF
--- a/Classes/Event/EventTypeResolver.php
+++ b/Classes/Event/EventTypeResolver.php
@@ -122,7 +122,7 @@ class EventTypeResolver
     }
 
     /**
-     * Create mapping between Event classname and Event type
+     * Create mapping between Event class name and Event type
      *
      * @param ObjectManagerInterface $objectManager
      * @return array
@@ -143,7 +143,11 @@ class EventTypeResolver
         /** @var ReflectionService $reflectionService */
         $reflectionService = $objectManager->get(ReflectionService::class);
         foreach ($reflectionService->getAllImplementationClassNamesForInterface(EventInterface::class) as $eventClassName) {
-            $type = $buildEventType($eventClassName);
+            if (is_subclass_of($eventClassName, ProvidesEventTypeIdentifierInterface::class)) {
+                $type = $eventClassName::getEventTypeIdentifier();
+            } else {
+                $type = $buildEventType($eventClassName);
+            }
             if (in_array($type, $mapping)) {
                 throw new Exception(sprintf('Duplicate event type "%s"', $type), 1474710799);
             }

--- a/Classes/Event/EventTypeResolver.php
+++ b/Classes/Event/EventTypeResolver.php
@@ -143,7 +143,7 @@ class EventTypeResolver
         /** @var ReflectionService $reflectionService */
         $reflectionService = $objectManager->get(ReflectionService::class);
         foreach ($reflectionService->getAllImplementationClassNamesForInterface(EventInterface::class) as $eventClassName) {
-            if (is_subclass_of($eventClassName, ProvidesEventTypeIdentifierInterface::class)) {
+            if (is_subclass_of($eventClassName, ProvidesEventTypeInterface::class)) {
                 $eventTypeIdentifier = $eventClassName::getEventTypeIdentifier();
             } else {
                 $type = $buildEventType($eventClassName);

--- a/Classes/Event/EventTypeResolver.php
+++ b/Classes/Event/EventTypeResolver.php
@@ -144,7 +144,7 @@ class EventTypeResolver
         $reflectionService = $objectManager->get(ReflectionService::class);
         foreach ($reflectionService->getAllImplementationClassNamesForInterface(EventInterface::class) as $eventClassName) {
             if (is_subclass_of($eventClassName, ProvidesEventTypeInterface::class)) {
-                $eventTypeIdentifier = $eventClassName::getEventTypeIdentifier();
+                $eventTypeIdentifier = $eventClassName::getEventType();
             } else {
                 $type = $buildEventType($eventClassName);
                 $eventTypeIdentifier = $buildEventType($eventClassName);

--- a/Classes/Event/EventTypeResolver.php
+++ b/Classes/Event/EventTypeResolver.php
@@ -144,14 +144,15 @@ class EventTypeResolver
         $reflectionService = $objectManager->get(ReflectionService::class);
         foreach ($reflectionService->getAllImplementationClassNamesForInterface(EventInterface::class) as $eventClassName) {
             if (is_subclass_of($eventClassName, ProvidesEventTypeIdentifierInterface::class)) {
-                $type = $eventClassName::getEventTypeIdentifier();
+                $eventTypeIdentifier = $eventClassName::getEventTypeIdentifier();
             } else {
                 $type = $buildEventType($eventClassName);
+                $eventTypeIdentifier = $buildEventType($eventClassName);
+                if (in_array($type, $mapping)) {
+                    throw new Exception(sprintf('Duplicate event type "%s"', $type), 1474710799);
+                }
             }
-            if (in_array($type, $mapping)) {
-                throw new Exception(sprintf('Duplicate event type "%s"', $type), 1474710799);
-            }
-            $mapping[$eventClassName] = $buildEventType($eventClassName);
+            $mapping[$eventClassName] = $eventTypeIdentifier;
         }
         return $mapping;
     }

--- a/Classes/Event/ProvidesEventTypeIdentifierInterface.php
+++ b/Classes/Event/ProvidesEventTypeIdentifierInterface.php
@@ -23,5 +23,5 @@ interface ProvidesEventTypeIdentifierInterface
      *
      * @return string
      */
-    static public function getEventTypeIdentifier(): string;
+    public static function getEventTypeIdentifier(): string;
 }

--- a/Classes/Event/ProvidesEventTypeIdentifierInterface.php
+++ b/Classes/Event/ProvidesEventTypeIdentifierInterface.php
@@ -1,0 +1,27 @@
+<?php
+namespace Neos\Cqrs\Event;
+
+/*
+ * This file is part of the Neos.Cqrs package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Interface for events which explicitly provide the name of the event stream they are listening to.
+ */
+interface ProvidesEventTypeIdentifierInterface
+{
+    /**
+     * Returns the identifier of the event type the event class represents.
+     *
+     * Example: "Acme.MyApplication:SomethingImportantHasHappened"
+     *
+     * @return string
+     */
+    static public function getEventTypeIdentifier(): string;
+}

--- a/Classes/Event/ProvidesEventTypeInterface.php
+++ b/Classes/Event/ProvidesEventTypeInterface.php
@@ -12,9 +12,9 @@ namespace Neos\Cqrs\Event;
  */
 
 /**
- * Interface for events which explicitly provide the name of the event stream they are listening to.
+ * Interface for event classes which explicitly provide the identifier for the event type they are representing.
  */
-interface ProvidesEventTypeIdentifierInterface
+interface ProvidesEventTypeInterface
 {
     /**
      * Returns the identifier of the event type the event class represents.
@@ -23,5 +23,5 @@ interface ProvidesEventTypeIdentifierInterface
      *
      * @return string
      */
-    public static function getEventTypeIdentifier(): string;
+    public static function getEventType(): string;
 }

--- a/Readme.md
+++ b/Readme.md
@@ -1,17 +1,17 @@
-# CQRS for Flow Framework
+# Event Sourcing and CQRS for Flow Framework
 
 _This package is currently under development and not fully working, please don't use it in production._
 
-The goal of the project is to provide infrastructure to support CQRS/ES project based on Flow Framework
+The goal of the project is to provide the infrastructure for ES/CQRS for applications based on Flow Framework.
 
 # Requirements
 
 * PHP 7
-* Flow 3.3 LTS
+* Flow 4.0
 
 # Packages
 
-The features are splitted in differents packages:
+The features are split into different packages:
 
 * **[Neos.Cqrs](https://github.com/neos/Neos.Cqrs)**: mostly infrastructure (interface, trait, abstract class) and the event/query bus
 * **[Neos.Cqrs.MonitoringHelper](https://github.com/neos/Neos.Cqrs.MonitoringHelper)**: aspect to monitor performance of the ```Neos.Cqrs``` infrastructure
@@ -173,6 +173,23 @@ infrastructure helpers (monitoring, debugging, ...).
         {
             return $this->amount;
         }
+    }
+
+An event class can also represent an event type from a remote system. The implementation is the same like a regular
+local event, except that it is mapped to an event type which is not supported by the automatic event class to
+event type mapping. Usually the event type identifier mapped to an event class follows the pattern
+`PackageKey:ShortEventTypeName`. A class representing a remote event can explicitly provide a custom event type:
+
+    final class SomethingHappenedElsewhere implements EventInterface, ProvidesEventTypeIdentifierInterface
+    {
+        /**
+         * @return string
+         */
+        static public function getEventTypeIdentifier(): string
+        {
+            return 'NotAcme.SomeRemotePAckage:SomethingHappened';
+        }
+        …
     }
 
 ### Generic Fault (WIP)

--- a/Readme.md
+++ b/Readme.md
@@ -180,14 +180,14 @@ local event, except that it is mapped to an event type which is not supported by
 event type mapping. Usually the event type identifier mapped to an event class follows the pattern
 `PackageKey:ShortEventTypeName`. A class representing a remote event can explicitly provide a custom event type:
 
-    final class SomethingHappenedElsewhere implements EventInterface, ProvidesEventTypeIdentifierInterface
+    final class SomethingHappenedElsewhere implements EventInterface, ProvidesEventTypeInterface
     {
         /**
          * @return string
          */
-        static public function getEventTypeIdentifier(): string
+        static public function getEventType(): string
         {
-            return 'NotAcme.SomeRemotePAckage:SomethingHappened';
+            return 'NotAcme.SomeRemotePackage:SomethingHappened';
         }
         …
     }


### PR DESCRIPTION
This change introduces a new optional interface for event implementations
which allows for overriding the event type identifier convention for the
event class to event type mapping.

This feature, for example, allows for implementing an event class which
represents a remote event.
