### PR TITLE
!!! TASK: Rename package to Neos.EventSourcing

### DIFF
--- a/Classes/Annotations/ReadModel.php
+++ b/Classes/Annotations/ReadModel.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Annotations;
+namespace Neos\EventSourcing\Annotations;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/Command/EventCommandController.php
+++ b/Classes/Command/EventCommandController.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Command;
+namespace Neos\EventSourcing\Command;
 
 /*
- * This file is part of the Neos.EventStore.DatabaseStorageAdapter package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\Command;
  * source code.
  */
 
-use Neos\Cqrs\Event\EventPublisher;
+use Neos\EventSourcing\Event\EventPublisher;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Core\Booting\Scripts;
@@ -43,7 +43,7 @@ class EventCommandController extends CommandController
      * @param bool $verbose If specified, this command will display information about the events being applied
      * @param bool $quiet If specified, this command won't produce any output apart from errors
      * @return void
-     * @see neos.cqrs:event:watch
+     * @see neos.eventsourcing:event:watch
      */
     public function catchUpCommand($verbose = false, $quiet = false)
     {
@@ -74,7 +74,7 @@ class EventCommandController extends CommandController
      * @param bool $verbose If specified, this command will display information about the events being applied
      * @param bool $quiet If specified, this command won't produce any output apart from errors (useful for automation)
      * @return void
-     * @see neos.cqrs:event:catchup
+     * @see neos.eventsourcing:event:catchup
      */
     public function watchCommand($lookupInterval = 10, $verbose = false, $quiet = false)
     {
@@ -87,7 +87,7 @@ class EventCommandController extends CommandController
                 'quiet' => $quiet ? 'yes' : 'no',
                 'verbose' => $verbose ? 'yes' : 'no'
             ];
-            Scripts::executeCommand('neos.cqrs:event:catchup', $this->flowSettings, !$quiet, $catchupCommandArguments);
+            Scripts::executeCommand('neos.eventsourcing:event:catchup', $this->flowSettings, !$quiet, $catchupCommandArguments);
             if (!$quiet) {
                 if ($verbose) {
                     $this->outputLine();

--- a/Classes/Command/EventStoreCommandController.php
+++ b/Classes/Command/EventStoreCommandController.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Command;
+namespace Neos\EventSourcing\Command;
 
 /*
- * This file is part of the Neos.EventStore.DatabaseStorageAdapter package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -12,8 +12,8 @@ namespace Neos\Cqrs\Command;
  */
 
 use Doctrine\DBAL\Exception\ConnectionException;
-use Neos\Cqrs\EventStore\Storage\Doctrine\Factory\ConnectionFactory;
-use Neos\Cqrs\EventStore\Storage\Doctrine\Schema\EventStoreSchema;
+use Neos\EventSourcing\EventStore\Storage\Doctrine\Factory\ConnectionFactory;
+use Neos\EventSourcing\EventStore\Storage\Doctrine\Schema\EventStoreSchema;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 

--- a/Classes/Command/ProjectionCommandController.php
+++ b/Classes/Command/ProjectionCommandController.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Command;
+namespace Neos\EventSourcing\Command;
 
 /*
- * This file is part of the Neos.EventStore.DatabaseStorageAdapter package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,9 +11,9 @@ namespace Neos\Cqrs\Command;
  * source code.
  */
 
-use Neos\Cqrs\Projection\InvalidProjectionIdentifierException;
-use Neos\Cqrs\Projection\Projection;
-use Neos\Cqrs\Projection\ProjectionManager;
+use Neos\EventSourcing\Projection\InvalidProjectionIdentifierException;
+use Neos\EventSourcing\Projection\Projection;
+use Neos\EventSourcing\Projection\ProjectionManager;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Core\Booting\Scripts;
@@ -74,7 +74,7 @@ class ProjectionCommandController extends CommandController
      *
      * @param string $projection The projection identifier; see projection:list for possible options
      * @return void
-     * @see neos.cqrs:projection:list
+     * @see neos.eventsourcing:projection:list
      */
     public function describeCommand($projection)
     {
@@ -104,8 +104,8 @@ class ProjectionCommandController extends CommandController
      * @param string $projection The projection identifier; see projection:list for possible options
      * @param bool $quiet If specified, this command won't produce any output apart from errors (useful for automation)
      * @return void
-     * @see neos.cqrs:projection:list
-     * @see neos.cqrs:projection:replayall
+     * @see neos.eventsourcing:projection:list
+     * @see neos.eventsourcing:projection:replayall
      */
     public function replayCommand($projection, $quiet = false)
     {
@@ -136,8 +136,8 @@ class ProjectionCommandController extends CommandController
      * @param bool $onlyEmpty If specified, only projections which are currently empty will be considered
      * @param bool $quiet If specified, this command won't produce any output apart from errors (useful for automation)
      * @return void
-     * @see neos.cqrs:projection:replay
-     * @see neos.cqrs:projection:list
+     * @see neos.eventsourcing:projection:replay
+     * @see neos.eventsourcing:projection:list
      */
     public function replayAllCommand($onlyEmpty = false, $quiet = false)
     {
@@ -179,8 +179,8 @@ class ProjectionCommandController extends CommandController
      * @param string $projection The projection identifier; see projection:list for possible options
      * @param bool $quiet If specified, this command won't produce any output apart from errors (useful for automation)
      * @return void
-     * @see neos.cqrs:projection:list
-     * @see neos.cqrs:projection:replay
+     * @see neos.eventsourcing:projection:list
+     * @see neos.eventsourcing:projection:replay
      */
     public function catchUpCommand($projection, $quiet = false)
     {
@@ -209,8 +209,8 @@ class ProjectionCommandController extends CommandController
      * @param int $lookupInterval Pause between lookups (in seconds)
      * @param bool $quiet If specified, this command won't produce any output apart from errors (useful for automation)
      * @return void
-     * @see neos.cqrs:projection:list
-     * @see neos.cqrs:projection:catchup
+     * @see neos.eventsourcing:projection:list
+     * @see neos.eventsourcing:projection:catchup
      */
     public function watchCommand($projection, $lookupInterval = 10, $quiet = false)
     {
@@ -224,7 +224,7 @@ class ProjectionCommandController extends CommandController
             if ($quiet) {
                 $catchupCommandArguments['quiet'] = true;
             }
-            Scripts::executeCommand('neos.cqrs:projection:catchup', $this->flowSettings, !$quiet, $catchupCommandArguments);
+            Scripts::executeCommand('neos.eventsourcing:projection:catchup', $this->flowSettings, !$quiet, $catchupCommandArguments);
             if (!$quiet) {
                 $this->outputLine();
             }

--- a/Classes/Domain/AbstractAggregateRoot.php
+++ b/Classes/Domain/AbstractAggregateRoot.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Domain;
+namespace Neos\EventSourcing\Domain;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,8 +11,8 @@ namespace Neos\Cqrs\Domain;
  * source code.
  */
 
-use Neos\Cqrs\Event\AggregateEventInterface;
-use Neos\Cqrs\Event\EventInterface;
+use Neos\EventSourcing\Event\AggregateEventInterface;
+use Neos\EventSourcing\Event\EventInterface;
 use Neos\Flow\Annotations as Flow;
 
 /**

--- a/Classes/Domain/AbstractEventSourcedAggregateRoot.php
+++ b/Classes/Domain/AbstractEventSourcedAggregateRoot.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Domain;
+namespace Neos\EventSourcing\Domain;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\Domain;
  * source code.
  */
 
-use Neos\Cqrs\EventStore\EventStream;
+use Neos\EventSourcing\EventStore\EventStream;
 
 /**
  * Base implementation for an event-sourced aggregate root

--- a/Classes/Domain/AggregateRootInterface.php
+++ b/Classes/Domain/AggregateRootInterface.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Domain;
+namespace Neos\EventSourcing\Domain;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\Domain;
  * source code.
  */
 
-use Neos\Cqrs\Event\EventInterface;
+use Neos\EventSourcing\Event\EventInterface;
 
 /**
  * AggregateRootInterface

--- a/Classes/Domain/EventSourcedAggregateRootInterface.php
+++ b/Classes/Domain/EventSourcedAggregateRootInterface.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Domain;
+namespace Neos\EventSourcing\Domain;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,14 +11,13 @@ namespace Neos\Cqrs\Domain;
  * source code.
  */
 
-use Neos\Cqrs\EventStore\EventStream;
+use Neos\EventSourcing\EventStore\EventStream;
 
 /**
  * Contract for event-sourced aggregate roots
  */
 interface EventSourcedAggregateRootInterface extends AggregateRootInterface
 {
-
     /**
      * The version of the event stream at time of reconstitution
      * This is used to avoid race conditions

--- a/Classes/Domain/Exception/AggregateRootNotFoundException.php
+++ b/Classes/Domain/Exception/AggregateRootNotFoundException.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Domain\Exception;
+namespace Neos\EventSourcing\Domain\Exception;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/Domain/RepositoryInterface.php
+++ b/Classes/Domain/RepositoryInterface.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Domain;
+namespace Neos\EventSourcing\Domain;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/Event/AbstractAggregateEvent.php
+++ b/Classes/Event/AbstractAggregateEvent.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Event;
+namespace Neos\EventSourcing\Event;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -10,7 +10,7 @@ namespace Neos\Cqrs\Event;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-use Neos\Cqrs\Exception;
+use Neos\EventSourcing\Exception;
 
 /**
  * Base class for events which are related to aggregates

--- a/Classes/Event/AggregateEventInterface.php
+++ b/Classes/Event/AggregateEventInterface.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Event;
+namespace Neos\EventSourcing\Event;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -10,7 +10,7 @@ namespace Neos\Cqrs\Event;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-use Neos\Cqrs\Exception;
+use Neos\EventSourcing\Exception;
 
 /**
  * Interface for events which are related to aggregates

--- a/Classes/Event/EventInterface.php
+++ b/Classes/Event/EventInterface.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Event;
+namespace Neos\EventSourcing\Event;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/Event/EventPublisher.php
+++ b/Classes/Event/EventPublisher.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Event;
+namespace Neos\EventSourcing\Event;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,15 +11,15 @@ namespace Neos\Cqrs\Event;
  * source code.
  */
 
-use Neos\Cqrs\EventListener\ActsBeforeInvokingEventListenerMethodsInterface;
-use Neos\Cqrs\EventListener\AsynchronousEventListenerInterface;
-use Neos\Cqrs\EventListener\EventListenerLocator;
-use Neos\Cqrs\EventStore\EventStore;
-use Neos\Cqrs\EventStore\EventTypesFilter;
-use Neos\Cqrs\EventStore\Exception\EventStreamNotFoundException;
-use Neos\Cqrs\EventStore\ExpectedVersion;
-use Neos\Cqrs\EventStore\WritableEvent;
-use Neos\Cqrs\EventStore\WritableEvents;
+use Neos\EventSourcing\EventListener\ActsBeforeInvokingEventListenerMethodsInterface;
+use Neos\EventSourcing\EventListener\AsynchronousEventListenerInterface;
+use Neos\EventSourcing\EventListener\EventListenerLocator;
+use Neos\EventSourcing\EventStore\EventStore;
+use Neos\EventSourcing\EventStore\EventTypesFilter;
+use Neos\EventSourcing\EventStore\Exception\EventStreamNotFoundException;
+use Neos\EventSourcing\EventStore\ExpectedVersion;
+use Neos\EventSourcing\EventStore\WritableEvent;
+use Neos\EventSourcing\EventStore\WritableEvents;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Property\PropertyMappingConfiguration;

--- a/Classes/Event/EventTypeResolver.php
+++ b/Classes/Event/EventTypeResolver.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Event;
+namespace Neos\EventSourcing\Event;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\Event;
  * source code.
  */
 
-use Neos\Cqrs\Exception;
+use Neos\EventSourcing\Exception;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;

--- a/Classes/Event/Exception/EventBusException.php
+++ b/Classes/Event/Exception/EventBusException.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Event\Exception;
+namespace Neos\EventSourcing\Event\Exception;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/Event/ProvidesEventTypeInterface.php
+++ b/Classes/Event/ProvidesEventTypeInterface.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Event;
+namespace Neos\EventSourcing\Event;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/EventListener/ActsBeforeInvokingEventListenerMethodsInterface.php
+++ b/Classes/EventListener/ActsBeforeInvokingEventListenerMethodsInterface.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventListener;
+namespace Neos\EventSourcing\EventListener;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -10,8 +10,8 @@ namespace Neos\Cqrs\EventListener;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-use Neos\Cqrs\Event\EventInterface;
-use Neos\Cqrs\EventStore\RawEvent;
+use Neos\EventSourcing\Event\EventInterface;
+use Neos\EventSourcing\EventStore\RawEvent;
 
 /**
  * ActsBeforeInvokingEventListenerMethodsInterface

--- a/Classes/EventListener/AppliedEventsLog.php
+++ b/Classes/EventListener/AppliedEventsLog.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventListener;
+namespace Neos\EventSourcing\EventListener;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/EventListener/AppliedEventsLogRepository.php
+++ b/Classes/EventListener/AppliedEventsLogRepository.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventListener;
+namespace Neos\EventSourcing\EventListener;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/EventListener/AsynchronousEventListenerInterface.php
+++ b/Classes/EventListener/AsynchronousEventListenerInterface.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventListener;
+namespace Neos\EventSourcing\EventListener;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/EventListener/EventListenerInterface.php
+++ b/Classes/EventListener/EventListenerInterface.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventListener;
+namespace Neos\EventSourcing\EventListener;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/EventListener/EventListenerLocator.php
+++ b/Classes/EventListener/EventListenerLocator.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventListener;
+namespace Neos\EventSourcing\EventListener;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,11 +11,11 @@ namespace Neos\Cqrs\EventListener;
  * source code.
  */
 
-use Neos\Cqrs\Event\EventInterface;
-use Neos\Cqrs\Event\EventTypeResolver;
-use Neos\Cqrs\EventStore\EventStore;
-use Neos\Cqrs\EventStore\RawEvent;
-use Neos\Cqrs\Exception;
+use Neos\EventSourcing\Event\EventInterface;
+use Neos\EventSourcing\Event\EventTypeResolver;
+use Neos\EventSourcing\EventStore\EventStore;
+use Neos\EventSourcing\EventStore\RawEvent;
+use Neos\EventSourcing\Exception;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;

--- a/Classes/EventStore/AbstractEventSourcedRepository.php
+++ b/Classes/EventStore/AbstractEventSourcedRepository.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore;
+namespace Neos\EventSourcing\EventStore;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,10 +11,10 @@ namespace Neos\Cqrs\EventStore;
  * source code.
  */
 
-use Neos\Cqrs\Domain\EventSourcedAggregateRootInterface;
-use Neos\Cqrs\Domain\Exception\AggregateRootNotFoundException;
-use Neos\Cqrs\Domain\RepositoryInterface;
-use Neos\Cqrs\Event\EventPublisher;
+use Neos\EventSourcing\Domain\EventSourcedAggregateRootInterface;
+use Neos\EventSourcing\Domain\Exception\AggregateRootNotFoundException;
+use Neos\EventSourcing\Domain\RepositoryInterface;
+use Neos\EventSourcing\Event\EventPublisher;
 use Neos\Flow\Annotations as Flow;
 
 /**

--- a/Classes/EventStore/EventAndRawEvent.php
+++ b/Classes/EventStore/EventAndRawEvent.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore;
+namespace Neos\EventSourcing\EventStore;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\EventStore;
  * source code.
  */
 
-use Neos\Cqrs\Event\EventInterface;
+use Neos\EventSourcing\Event\EventInterface;
 
 /**
  * Wrapper for a event that was loaded from the Event Store.

--- a/Classes/EventStore/EventStore.php
+++ b/Classes/EventStore/EventStore.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore;
+namespace Neos\EventSourcing\EventStore;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,8 +11,8 @@ namespace Neos\Cqrs\EventStore;
  * source code.
  */
 
-use Neos\Cqrs\EventStore\Exception\EventStreamNotFoundException;
-use Neos\Cqrs\EventStore\Storage\EventStorageInterface;
+use Neos\EventSourcing\EventStore\Exception\EventStreamNotFoundException;
+use Neos\EventSourcing\EventStore\Storage\EventStorageInterface;
 use Neos\Flow\Annotations as Flow;
 
 /**

--- a/Classes/EventStore/EventStream.php
+++ b/Classes/EventStore/EventStream.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore;
+namespace Neos\EventSourcing\EventStore;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\EventStore;
  * source code.
  */
 
-use Neos\Cqrs\Event\EventTypeResolver;
+use Neos\EventSourcing\Event\EventTypeResolver;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Property\PropertyMappingConfiguration;

--- a/Classes/EventStore/EventStreamFilterInterface.php
+++ b/Classes/EventStore/EventStreamFilterInterface.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore;
+namespace Neos\EventSourcing\EventStore;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/EventStore/EventStreamResolver.php
+++ b/Classes/EventStore/EventStreamResolver.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore;
+namespace Neos\EventSourcing\EventStore;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\EventStore;
  * source code.
  */
 
-use Neos\Cqrs\Domain\AggregateRootInterface;
+use Neos\EventSourcing\Domain\AggregateRootInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Package\PackageManagerInterface;

--- a/Classes/EventStore/EventTypesFilter.php
+++ b/Classes/EventStore/EventTypesFilter.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore;
+namespace Neos\EventSourcing\EventStore;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\EventStore;
  * source code.
  */
 
-use Neos\Cqrs\Exception;
+use Neos\EventSourcing\Exception;
 use Neos\Flow\Annotations as Flow;
 
 class EventTypesFilter implements EventStreamFilterInterface

--- a/Classes/EventStore/Exception/ConcurrencyException.php
+++ b/Classes/EventStore/Exception/ConcurrencyException.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore\Exception;
+namespace Neos\EventSourcing\EventStore\Exception;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\EventStore\Exception;
  * source code.
  */
 
-use Neos\Cqrs\RuntimeException;
+use Neos\EventSourcing\RuntimeException;
 
 class ConcurrencyException extends RuntimeException
 {

--- a/Classes/EventStore/Exception/EventStreamNotFoundException.php
+++ b/Classes/EventStore/Exception/EventStreamNotFoundException.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore\Exception;
+namespace Neos\EventSourcing\EventStore\Exception;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\EventStore\Exception;
  * source code.
  */
 
-use Neos\Cqrs\RuntimeException;
+use Neos\EventSourcing\RuntimeException;
 
 class EventStreamNotFoundException extends RuntimeException
 {

--- a/Classes/EventStore/ExpectedVersion.php
+++ b/Classes/EventStore/ExpectedVersion.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore;
+namespace Neos\EventSourcing\EventStore;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/EventStore/RawEvent.php
+++ b/Classes/EventStore/RawEvent.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore;
+namespace Neos\EventSourcing\EventStore;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineEventStorage.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore\Storage\Doctrine;
+namespace Neos\EventSourcing\EventStore\Storage\Doctrine;
 
 /*
- * This file is part of the Neos.EventStore.DatabaseStorageAdapter package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -14,16 +14,16 @@ namespace Neos\Cqrs\EventStore\Storage\Doctrine;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Types\Type;
-use Neos\Cqrs\Event\EventTypeResolver;
-use Neos\Cqrs\EventStore\EventStream;
-use Neos\Cqrs\EventStore\EventStreamFilterInterface;
-use Neos\Cqrs\EventStore\Exception\ConcurrencyException;
-use Neos\Cqrs\EventStore\ExpectedVersion;
-use Neos\Cqrs\EventStore\Storage\Doctrine\Factory\ConnectionFactory;
-use Neos\Cqrs\EventStore\Storage\EventStorageInterface;
-use Neos\Cqrs\EventStore\RawEvent;
-use Neos\Cqrs\EventStore\StreamNameFilter;
-use Neos\Cqrs\EventStore\WritableEvents;
+use Neos\EventSourcing\Event\EventTypeResolver;
+use Neos\EventSourcing\EventStore\EventStream;
+use Neos\EventSourcing\EventStore\EventStreamFilterInterface;
+use Neos\EventSourcing\EventStore\Exception\ConcurrencyException;
+use Neos\EventSourcing\EventStore\ExpectedVersion;
+use Neos\EventSourcing\EventStore\Storage\Doctrine\Factory\ConnectionFactory;
+use Neos\EventSourcing\EventStore\Storage\EventStorageInterface;
+use Neos\EventSourcing\EventStore\RawEvent;
+use Neos\EventSourcing\EventStore\StreamNameFilter;
+use Neos\EventSourcing\EventStore\WritableEvents;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Utility\Now;

--- a/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
+++ b/Classes/EventStore/Storage/Doctrine/DoctrineStreamIterator.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore\Storage\Doctrine;
+namespace Neos\EventSourcing\EventStore\Storage\Doctrine;
 
 /*
- * This file is part of the Neos.EventStore.DatabaseStorageAdapter package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -12,7 +12,7 @@ namespace Neos\Cqrs\EventStore\Storage\Doctrine;
  */
 
 use Doctrine\DBAL\Query\QueryBuilder;
-use Neos\Cqrs\EventStore\RawEvent;
+use Neos\EventSourcing\EventStore\RawEvent;
 
 /**
  * Stream Iterator for the doctrine based EventStore

--- a/Classes/EventStore/Storage/Doctrine/Factory/ConnectionFactory.php
+++ b/Classes/EventStore/Storage/Doctrine/Factory/ConnectionFactory.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore\Storage\Doctrine\Factory;
+namespace Neos\EventSourcing\EventStore\Storage\Doctrine\Factory;
 
 /*
- * This file is part of the Neos.EventStore.DatabaseStorageAdapter package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/EventStore/Storage/Doctrine/Schema/EventStoreSchema.php
+++ b/Classes/EventStore/Storage/Doctrine/Schema/EventStoreSchema.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore\Storage\Doctrine\Schema;
+namespace Neos\EventSourcing\EventStore\Storage\Doctrine\Schema;
 
 /*
- * This file is part of the Neos.EventStore.DatabaseStorageAdapter package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/EventStore/Storage/EventStorageInterface.php
+++ b/Classes/EventStore/Storage/EventStorageInterface.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore\Storage;
+namespace Neos\EventSourcing\EventStore\Storage;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,11 +11,11 @@ namespace Neos\Cqrs\EventStore\Storage;
  * source code.
  */
 
-use Neos\Cqrs\EventStore\EventStream;
-use Neos\Cqrs\EventStore\EventStreamFilterInterface;
-use Neos\Cqrs\EventStore\ExpectedVersion;
-use Neos\Cqrs\EventStore\RawEvent;
-use Neos\Cqrs\EventStore\WritableEvents;
+use Neos\EventSourcing\EventStore\EventStream;
+use Neos\EventSourcing\EventStore\EventStreamFilterInterface;
+use Neos\EventSourcing\EventStore\ExpectedVersion;
+use Neos\EventSourcing\EventStore\RawEvent;
+use Neos\EventSourcing\EventStore\WritableEvents;
 
 /**
  * EventStorageInterface

--- a/Classes/EventStore/StreamNameFilter.php
+++ b/Classes/EventStore/StreamNameFilter.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore;
+namespace Neos\EventSourcing\EventStore;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\EventStore;
  * source code.
  */
 
-use Neos\Cqrs\Exception;
+use Neos\EventSourcing\Exception;
 use Neos\Flow\Annotations as Flow;
 
 class StreamNameFilter implements EventStreamFilterInterface

--- a/Classes/EventStore/StreamNameResolver.php
+++ b/Classes/EventStore/StreamNameResolver.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore;
+namespace Neos\EventSourcing\EventStore;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\EventStore;
  * source code.
  */
 
-use Neos\Cqrs\Domain\AggregateRootInterface;
+use Neos\EventSourcing\Domain\AggregateRootInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ClassReflection;

--- a/Classes/EventStore/WritableEvent.php
+++ b/Classes/EventStore/WritableEvent.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore;
+namespace Neos\EventSourcing\EventStore;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/EventStore/WritableEvents.php
+++ b/Classes/EventStore/WritableEvents.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\EventStore;
+namespace Neos\EventSourcing\EventStore;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/Exception.php
+++ b/Classes/Exception.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs;
+namespace Neos\EventSourcing;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs;
+namespace Neos\EventSourcing;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,12 +11,12 @@ namespace Neos\Cqrs;
  * source code.
  */
 
-use Neos\Cqrs\Projection\Doctrine\DoctrineProjectionPersistenceManager;
+use Neos\EventSourcing\Projection\Doctrine\DoctrineProjectionPersistenceManager;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Package\Package as BasePackage;
 
 /**
- * The Neos.Cqrs Package
+ * The Neos.EventSourcing Package
  */
 class Package extends BasePackage
 {

--- a/Classes/ProcessManager/AbstractAsynchronousProcessManager.php
+++ b/Classes/ProcessManager/AbstractAsynchronousProcessManager.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\ProcessManager;
+namespace Neos\EventSourcing\ProcessManager;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,8 +11,8 @@ namespace Neos\Cqrs\ProcessManager;
  * source code.
  */
 
-use Neos\Cqrs\EventListener\AppliedEventsLogRepository;
-use Neos\Cqrs\EventListener\AsynchronousEventListenerInterface;
+use Neos\EventSourcing\EventListener\AppliedEventsLogRepository;
+use Neos\EventSourcing\EventListener\AsynchronousEventListenerInterface;
 use Neos\Flow\Annotations as Flow;
 
 /**

--- a/Classes/ProcessManager/AbstractProcessManager.php
+++ b/Classes/ProcessManager/AbstractProcessManager.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\ProcessManager;
+namespace Neos\EventSourcing\ProcessManager;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -10,12 +10,12 @@ namespace Neos\Cqrs\ProcessManager;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-use Neos\Cqrs\Event\EventInterface;
-use Neos\Cqrs\EventListener\EventListenerInterface;
-use Neos\Cqrs\EventListener\ActsBeforeInvokingEventListenerMethodsInterface;
-use Neos\Cqrs\EventStore\RawEvent;
-use Neos\Cqrs\ProcessManager\State\ProcessState;
-use Neos\Cqrs\ProcessManager\State\StateRepository;
+use Neos\EventSourcing\Event\EventInterface;
+use Neos\EventSourcing\EventListener\EventListenerInterface;
+use Neos\EventSourcing\EventListener\ActsBeforeInvokingEventListenerMethodsInterface;
+use Neos\EventSourcing\EventStore\RawEvent;
+use Neos\EventSourcing\ProcessManager\State\ProcessState;
+use Neos\EventSourcing\ProcessManager\State\StateRepository;
 use Neos\Flow\Annotations as Flow;
 
 /**

--- a/Classes/ProcessManager/ProcessManagerException.php
+++ b/Classes/ProcessManager/ProcessManagerException.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\ProcessManager;
+namespace Neos\EventSourcing\ProcessManager;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -10,7 +10,7 @@ namespace Neos\Cqrs\ProcessManager;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-use Neos\Cqrs\Exception;
+use Neos\EventSourcing\Exception;
 
 /**
  * ProcessManagerException

--- a/Classes/ProcessManager/State/ProcessState.php
+++ b/Classes/ProcessManager/State/ProcessState.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\ProcessManager\State;
+namespace Neos\EventSourcing\ProcessManager\State;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/ProcessManager/State/StateRepository.php
+++ b/Classes/ProcessManager/State/StateRepository.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\ProcessManager\State;
+namespace Neos\EventSourcing\ProcessManager\State;
 
 /*
- * This file is part of the Neos.EventStore package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/Projection/AbstractBaseProjector.php
+++ b/Classes/Projection/AbstractBaseProjector.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Projection;
+namespace Neos\EventSourcing\Projection;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/Projection/Doctrine/AbstractAsynchronousDoctrineProjector.php
+++ b/Classes/Projection/Doctrine/AbstractAsynchronousDoctrineProjector.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Projection\Doctrine;
+namespace Neos\EventSourcing\Projection\Doctrine;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,8 +11,8 @@ namespace Neos\Cqrs\Projection\Doctrine;
  * source code.
  */
 
-use Neos\Cqrs\EventListener\AppliedEventsLogRepository;
-use Neos\Cqrs\EventListener\AsynchronousEventListenerInterface;
+use Neos\EventSourcing\EventListener\AppliedEventsLogRepository;
+use Neos\EventSourcing\EventListener\AsynchronousEventListenerInterface;
 use Neos\Flow\Annotations as Flow;
 
 /**

--- a/Classes/Projection/Doctrine/AbstractDoctrineFinder.php
+++ b/Classes/Projection/Doctrine/AbstractDoctrineFinder.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Projection\Doctrine;
+namespace Neos\EventSourcing\Projection\Doctrine;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/Projection/Doctrine/AbstractDoctrineProjector.php
+++ b/Classes/Projection/Doctrine/AbstractDoctrineProjector.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Projection\Doctrine;
+namespace Neos\EventSourcing\Projection\Doctrine;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,8 +11,8 @@ namespace Neos\Cqrs\Projection\Doctrine;
  * source code.
  */
 
-use Neos\Cqrs\Exception;
-use Neos\Cqrs\Projection\AbstractBaseProjector;
+use Neos\EventSourcing\Exception;
+use Neos\EventSourcing\Projection\AbstractBaseProjector;
 use Neos\Flow\Annotations as Flow;
 
 /**

--- a/Classes/Projection/Doctrine/DoctrineProjectionPersistenceManager.php
+++ b/Classes/Projection/Doctrine/DoctrineProjectionPersistenceManager.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Projection\Doctrine;
+namespace Neos\EventSourcing\Projection\Doctrine;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -15,7 +15,7 @@ use Doctrine\Common\Persistence\ObjectManager as DoctrineObjectManager;
 use Doctrine\ORM\EntityManager as DoctrineEntityManager;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\UnitOfWork;
-use Neos\Cqrs\Exception;
+use Neos\EventSourcing\Exception;
 use Neos\Flow\Log\SystemLoggerInterface;
 use Neos\Flow\Annotations as Flow;
 

--- a/Classes/Projection/InvalidProjectionIdentifierException.php
+++ b/Classes/Projection/InvalidProjectionIdentifierException.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Projection;
+namespace Neos\EventSourcing\Projection;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\Projection;
  * source code.
  */
 
-use Neos\Cqrs\Exception;
+use Neos\EventSourcing\Exception;
 use Neos\Flow\Annotations as Flow;
 
 /**

--- a/Classes/Projection/Projection.php
+++ b/Classes/Projection/Projection.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Projection;
+namespace Neos\EventSourcing\Projection;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\Projection;
  * source code.
  */
 
-use Neos\Cqrs\EventListener\AsynchronousEventListenerInterface;
+use Neos\EventSourcing\EventListener\AsynchronousEventListenerInterface;
 use Neos\Flow\Annotations as Flow;
 
 /**

--- a/Classes/Projection/ProjectionManager.php
+++ b/Classes/Projection/ProjectionManager.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Projection;
+namespace Neos\EventSourcing\Projection;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,12 +11,12 @@ namespace Neos\Cqrs\Projection;
  * source code.
  */
 
-use Neos\Cqrs\Event\EventTypeResolver;
-use Neos\Cqrs\EventListener\EventListenerLocator;
-use Neos\Cqrs\EventListener\AsynchronousEventListenerInterface;
-use Neos\Cqrs\EventStore\EventStore;
-use Neos\Cqrs\EventStore\EventTypesFilter;
-use Neos\Cqrs\EventStore\Exception\EventStreamNotFoundException;
+use Neos\EventSourcing\Event\EventTypeResolver;
+use Neos\EventSourcing\EventListener\EventListenerLocator;
+use Neos\EventSourcing\EventListener\AsynchronousEventListenerInterface;
+use Neos\EventSourcing\EventStore\EventStore;
+use Neos\EventSourcing\EventStore\EventTypesFilter;
+use Neos\EventSourcing\EventStore\Exception\EventStreamNotFoundException;
 use Neos\Flow\Annotations as Flow;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;

--- a/Classes/Projection/ProjectorInterface.php
+++ b/Classes/Projection/ProjectorInterface.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\Projection;
+namespace Neos\EventSourcing\Projection;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\Projection;
  * source code.
  */
 
-use Neos\Cqrs\EventListener\EventListenerInterface;
+use Neos\EventSourcing\EventListener\EventListenerInterface;
 
 /**
  * ProjectorInterface

--- a/Classes/RuntimeException.php
+++ b/Classes/RuntimeException.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs;
+namespace Neos\EventSourcing;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Classes/TypeConverter/EventToArrayConverter.php
+++ b/Classes/TypeConverter/EventToArrayConverter.php
@@ -1,8 +1,8 @@
 <?php
-namespace Neos\Cqrs\TypeConverter;
+namespace Neos\EventSourcing\TypeConverter;
 
 /*
- * This file is part of the Neos.Cqrs package.
+ * This file is part of the Neos.EventSourcing package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,7 +11,7 @@ namespace Neos\Cqrs\TypeConverter;
  * source code.
  */
 
-use Neos\Cqrs\Event\EventInterface;
+use Neos\EventSourcing\Event\EventInterface;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
 use Neos\Utility\ObjectAccess;

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,7 +1,7 @@
-Neos\Cqrs\EventStore\Storage\EventStorageInterface:
-  className: Neos\Cqrs\EventStore\Storage\Doctrine\DoctrineEventStorage
+Neos\EventSourcing\EventStore\Storage\EventStorageInterface:
+  className: Neos\EventSourcing\EventStore\Storage\Doctrine\DoctrineEventStorage
 
-Neos\Cqrs\Projection\ProjectionManager:
+Neos\EventSourcing\Projection\ProjectionManager:
   properties:
     'projectionCache':
       object:
@@ -9,4 +9,4 @@ Neos\Cqrs\Projection\ProjectionManager:
         factoryMethodName: getCache
         arguments:
           1:
-            value: 'Neos_Cqrs_ProjectionCache'
+            value: 'Neos_EventSourcing_ProjectionCache'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,10 +1,10 @@
 
 Neos:
-  Cqrs:
+  EventSourcing:
     EventStore:
       storage:
         options:
-          eventTableName: neos_cqrs_events
+          eventTableName: neos_eventsourcing_eventstore_events
           backendOptions:
             driver: pdo_mysql
             host: 127.0.0.1
@@ -17,4 +17,4 @@ Neos:
       doctrine:
         migrations:
           ignoredTables:
-            neos_cqrs_events: true
+            neos_eventsourcing_eventstore_events: true

--- a/Migrations/Mysql/Version20161216132312.php
+++ b/Migrations/Mysql/Version20161216132312.php
@@ -1,0 +1,42 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Rename package to Neos.EventSourcing
+ */
+class Version20161216132312 extends AbstractMigration
+{
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Rename package to Neos.EventSourcing';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+        $this->addSql('RENAME TABLE neos_cqrs_processmanager_state_processstate TO neos_eventsourcing_processmanager_state_processstate');
+        $this->addSql('RENAME TABLE neos_cqrs_eventlistener_appliedeventslog TO neos_eventsourcing_eventlistener_appliedeventslog');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+        $this->addSql('RENAME TABLE neos_eventsourcing_processmanager_state_processstate TO neos_cqrs_processmanager_state_processstate');
+        $this->addSql('RENAME TABLE neos_eventsourcing_eventlistener_appliedeventslog TO neos_cqrs_eventlistener_appliedeventslog');
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -13,11 +13,11 @@ The goal of the project is to provide the infrastructure for ES/CQRS for applica
 
 The features are split into different packages:
 
-* **[Neos.Cqrs](https://github.com/neos/Neos.Cqrs)**: mostly infrastructure (interface, trait, abstract class) and the event/query bus
-* **[Neos.Cqrs.MonitoringHelper](https://github.com/neos/Neos.Cqrs.MonitoringHelper)**: aspect to monitor performance of the ```Neos.Cqrs``` infrastructure
-* **[Neos.EventStore](https://github.com/neos/Neos.EventStore)**: event store to support event sourcing
-* **[Neos.EventStore.InMemoryStorageAdapter](https://github.com/neos/Neos.EventStore.InMemoryStorageAdapter)**: in memory event storage, mainly for testing
-* **[Neos.EventStore.DatabaseStorageAdapter](https://github.com/neos/Neos.EventStore.DatabaseStorageAdapter)**: doctrine dbal based event storage
+* **[Neos.EventSourcing](https://github.com/neos/Neos.EventSourcing)**: mostly infrastructure (interface, trait, abstract class) and the event/query bus
+* **[Neos.EventSourcing.MonitoringHelper](https://github.com/neos/Neos.EventSourcing.MonitoringHelper)**: aspect to monitor performance of the ```Neos.EventSourcing``` infrastructure
+* **[Neos.EventSourcing](https://github.com/neos/Neos.EventSourcing)**: event store to support event sourcing
+* **[Neos.EventSourcing.InMemoryStorageAdapter](https://github.com/neos/Neos.EventSourcing.InMemoryStorageAdapter)**: in memory event storage, mainly for testing
+* **[Neos.EventSourcing.DatabaseStorageAdapter](https://github.com/neos/Neos.EventSourcing.DatabaseStorageAdapter)**: doctrine dbal based event storage
 
 More storage can be added later (Redis, ...).
 
@@ -52,7 +52,7 @@ This is a PSR-4 package structure:
 
 # Components
 
-Currently most components are included in the ```Neos.Cqrs``` package. In the future some components can be split into
+Currently most components are included in the ```Neos.EventSourcing``` package. In the future some components can be split into
 separate packages for more flexibility.
 
 ## Command
@@ -229,7 +229,7 @@ All the wiring between event is done automatically, if you respect the following
 
 ## EventStore
 
-See package **Neos.EventStore**.
+See package **Neos.EventSourcing**.
 
 ## Message
 
@@ -277,7 +277,7 @@ use TYPO3\Media\Domain\Model\AssetInterface;
 use TYPO3\Media\Domain\Repository\AssetRepository;
 use TYPO3\Flow\Annotations as Flow;
 use Doctrine\ORM\Mapping as ORM;
-use Neos\Cqrs\Annotations as CQRS;
+use Neos\EventSourcing\Annotations as CQRS;
 
 /**
  * General purpose Organization Read Model
@@ -362,7 +362,7 @@ namespace Acme\Application\Projection\Organization;
 use Acme\Domain\Aggregate\Organization\Event\OrganizationHasBeenCreated;
 use Acme\Domain\Aggregate\Organization\Event\OrganizationHasBeenDeleted;
 use Acme\Domain\Aggregate\Organization\Event\OrganizationLogoHasBeenChanged;
-use Neos\Cqrs\Projection\Doctrine\AbstractDoctrineProjector;
+use Neos\EventSourcing\Projection\Doctrine\AbstractDoctrineProjector;
 use TYPO3\Flow\Annotations as Flow;
 
 /**
@@ -417,7 +417,7 @@ The corresponding Finder class providing the query methods may look as simple as
 ```php
 namespace Acme\Application\Projection\Organization;
 
-use Neos\Cqrs\Projection\Doctrine\AbstractDoctrineFinder;
+use Neos\EventSourcing\Projection\Doctrine\AbstractDoctrineFinder;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Persistence\QueryInterface;
 

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,17 @@
 {
-    "name": "neos/cqrs",
-    "type": "typo3-flow-package",
-    "description": "Lean and opinionated way to integrate CQRS pattern in your Flow framework package",
+    "name": "neos/eventsourcing",
+    "type": "neos-package",
+    "description": "Lean and opinionated way to integrate Event Sourcing and CQRS pattern in your Flow framework package",
     "require": {
         "php": ">=7.0.1",
-        "typo3/flow": ">=2.3"
+        "typo3/flow": ">=4.0"
     },
     "suggest": {
         "php-uuid": "For fast generation of UUIDs used in the persistence."
     },
     "autoload": {
         "psr-4": {
-            "Neos\\Cqrs\\": "Classes"
+            "Neos\\EventSourcing\\": "Classes"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "neos/eventsourcing",
+    "name": "neos/event-sourcing",
     "type": "neos-package",
     "description": "Lean and opinionated way to integrate Event Sourcing and CQRS pattern in your Flow framework package",
     "require": {


### PR DESCRIPTION
This renames the Neos.Cqrs package to Neos.EventSourcing.

The most important adjustments for your own packages are:

- refer to `neos/eventsourcing` instead of `neos/cqrs` in your composer.json
- use `Neos\EventSourcing` instead of `Neos\Cqrs` for namespaces
- manually rename (or re-create) the event store table to `neos_eventsourcing_eventstore_events`

Resolves: #93