### PR TITLE
WIP: Snapshot create and restore support for projections

### DIFF
--- a/Classes/Projection/DoctrineProjectorSnapshotTrait.php
+++ b/Classes/Projection/DoctrineProjectorSnapshotTrait.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventSourcing\Projection;
+
+/*
+ * This file is part of the Neos.EventSourcing package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
+use Neos\EventSourcing\EventListener\AppliedEventsStorage\DoctrineAppliedEventsStorage;
+
+trait DoctrineProjectorSnapshotTrait
+{
+    /**
+     * @return Connection
+     */
+    abstract protected function getDatabaseConnection(): Connection;
+
+    /**
+     * Returns the database table names used by the concrete projection
+     *
+     * @return array
+     */
+    abstract protected static function getTableNames(): array;
+
+    /**
+     * @param SnapshotIdentifier $snapshotIdentifier
+     * @return int The event sequence number at which the snapshot was created
+     * @throws DBALException
+     */
+    public function createSnapshot(SnapshotIdentifier $snapshotIdentifier): int
+    {
+        $databaseConnection = $this->getDatabaseConnection();
+        $doctrineAppliedEventsStorage = new DoctrineAppliedEventsStorage($databaseConnection, get_class($this));
+
+        $eventSequenceNumber = $doctrineAppliedEventsStorage->reserveHighestAppliedEventSequenceNumber();
+
+        foreach (static::getTableNames() as $tableName) {
+            $snapshotTableName = $this->renderUtilityTableName('snap', $snapshotIdentifier, $tableName);
+
+            $databaseConnection->exec(sprintf('DROP TABLE IF EXISTS %s', $snapshotTableName));
+            $databaseConnection->exec(sprintf('CREATE TABLE %s AS SELECT * FROM %s', $snapshotTableName, $tableName));
+        }
+
+        $doctrineAppliedEventsStorage->releaseHighestAppliedSequenceNumber();
+        return $eventSequenceNumber;
+    }
+
+    /**
+     * @param Snapshot $snapshot
+     * @throws DBALException
+     */
+    public function restoreSnapshot(Snapshot $snapshot): void
+    {
+        $databaseConnection = $this->getDatabaseConnection();
+        $doctrineAppliedEventsStorage = new DoctrineAppliedEventsStorage($databaseConnection, get_class($this));
+
+        foreach (static::getTableNames() as $originalTableName) {
+            $snapshotTableName = $this->renderUtilityTableName('snap', $snapshot->getSnapshotIdentifier(), $originalTableName);
+            $temporaryTableName = $this->renderUtilityTableName('temp', $snapshot->getSnapshotIdentifier(), $originalTableName);
+
+            $databaseConnection->exec(sprintf('DROP TABLE IF EXISTS %s', $temporaryTableName));
+            $databaseConnection->exec(sprintf('CREATE TABLE %s AS SELECT * FROM %s', $temporaryTableName, $snapshotTableName));
+        }
+
+        $doctrineAppliedEventsStorage->reserveHighestAppliedEventSequenceNumber();
+
+        $tablesToTrash = [];
+        foreach (static::getTableNames() as $originalTableName) {
+            $temporaryTableName = $this->renderUtilityTableName('temp', $snapshot->getSnapshotIdentifier(), $originalTableName);
+            $trashTableName = $this->renderUtilityTableName('trash', $snapshot->getSnapshotIdentifier(), $originalTableName);
+            $tablesToTrash[] = $trashTableName;
+
+            $databaseConnection->exec(sprintf('ALTER TABLE %s RENAME TO %s', $originalTableName, $trashTableName));
+            $databaseConnection->exec(sprintf('ALTER TABLE %s RENAME TO %s', $temporaryTableName, $originalTableName));
+        }
+
+        $doctrineAppliedEventsStorage->saveHighestAppliedSequenceNumber($snapshot->getEventSequenceNumber());
+
+        foreach ($tablesToTrash as $originalTableName) {
+            $databaseConnection->exec(sprintf('DROP TABLE %s', $originalTableName));
+        }
+    }
+
+    /**
+     * Renders a unique, modestly telling and not too long table name for a snapshot
+     *
+     * @param string $prefix An up to 5 character long prefix: "snap", "trash" or "temp"
+     * @param SnapshotIdentifier $snapshotIdentifier
+     * @param string $originalTableName
+     * @return string
+     */
+    protected function renderUtilityTableName(string $prefix, SnapshotIdentifier $snapshotIdentifier, string $originalTableName): string
+    {
+        $utilityTableName = $prefix . '_' . str_replace('-', '_', $snapshotIdentifier) . '_' . substr(str_replace('_', '', $originalTableName), -12) . '_' . substr(sha1($originalTableName), -8);
+        assert(strlen($utilityTableName) <= 64);
+        return $utilityTableName;
+    }
+}

--- a/Classes/Projection/Snapshot.php
+++ b/Classes/Projection/Snapshot.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventSourcing\Projection;
+
+/*
+ * This file is part of the Neos.EventSourcing package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * SnapshotAwareProjectorInterface
+ */
+class Snapshot
+{
+    /**
+     * @var SnapshotIdentifier
+     */
+    private $snapshotIdentifier;
+
+    /**
+     * @var string
+     */
+    private $projectionIdentifier;
+
+    /**
+     * @var int
+     */
+    private $eventSequenceNumber;
+
+    /**
+     * @var \DateTimeImmutable
+     */
+    private $createdAt;
+
+    /**
+     * @param SnapshotIdentifier $snapshotIdentifier
+     * @param string $projectionIdentifier
+     * @param int $eventSequenceNumber
+     * @param \DateTimeImmutable $createdAt
+     */
+    public function __construct(SnapshotIdentifier $snapshotIdentifier, string $projectionIdentifier, int $eventSequenceNumber, \DateTimeImmutable $createdAt)
+    {
+        $this->snapshotIdentifier = $snapshotIdentifier;
+        $this->projectionIdentifier = $projectionIdentifier;
+        $this->eventSequenceNumber = $eventSequenceNumber;
+        $this->createdAt = $createdAt;
+    }
+
+    /**
+     * @return SnapshotIdentifier
+     */
+    public function getSnapshotIdentifier(): SnapshotIdentifier
+    {
+        return $this->snapshotIdentifier;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProjectionIdentifier(): string
+    {
+        return $this->projectionIdentifier;
+    }
+
+    /**
+     * @return int
+     */
+    public function getEventSequenceNumber(): int
+    {
+        return $this->eventSequenceNumber;
+    }
+
+    /**
+     * @return \DateTimeImmutable
+     */
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/Classes/Projection/SnapshotAwareProjectorInterface.php
+++ b/Classes/Projection/SnapshotAwareProjectorInterface.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventSourcing\Projection;
+
+/*
+ * This file is part of the Neos.EventSourcing package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * SnapshotAwareProjectorInterface
+ */
+interface SnapshotAwareProjectorInterface extends ProjectorInterface
+{
+    /**
+     * @param SnapshotIdentifier $snapshotIdentifier
+     * @return int The event sequence number at which the snapshot was created
+     */
+    public function createSnapshot(SnapshotIdentifier $snapshotIdentifier): int;
+}

--- a/Classes/Projection/SnapshotIdentifier.php
+++ b/Classes/Projection/SnapshotIdentifier.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventSourcing\Projection;
+
+/*
+ * This file is part of the Neos.EventSourcing package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Ramsey\Uuid\Uuid;
+
+/**
+ * SnapshotIdentifier
+ */
+class SnapshotIdentifier
+{
+
+    /**
+     * @var string
+     */
+    private $snapshotIdentifier;
+
+    /**
+     * @param string $snapshotIdentifier
+     */
+    public function __construct(string $snapshotIdentifier)
+    {
+        $this->setSnapshotIdentifier($snapshotIdentifier);
+    }
+
+    /**
+     * @param string $snapshotIdentifier
+     */
+    private function setSnapshotIdentifier(string $snapshotIdentifier): void
+    {
+        if (preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/', $snapshotIdentifier) !== 1) {
+            throw new \InvalidArgumentException(sprintf('Invalid snapshot identifier "%s"', $snapshotIdentifier), 1598000542);
+        }
+        $this->snapshotIdentifier = $snapshotIdentifier;
+    }
+
+    /**
+     * Create a SnapshotIdentifier object from the given string
+     *
+     * @param string $snapshotIdentifier
+     * @return static
+     */
+    public static function fromString(string $snapshotIdentifier): self
+    {
+        return new static($snapshotIdentifier);
+    }
+
+    /**
+     * @return static
+     * @throws
+     */
+    public static function fromRandom(): self
+    {
+        return self::fromString(Uuid::uuid4()->toString());
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->snapshotIdentifier;
+    }
+}


### PR DESCRIPTION
- [x] interface for `createSnapshot()` and `restoreSnapshot()`
- [x] CLI commands for create snapshot and restore snapshot
- [x] trait for Doctrine based Projectors helping with creating and restoring of snapshots
- [ ] persist `Snapshot` objects so that `ProjectionManager` and others can look up which snapshots (should) exist and retrieve metadata
- [ ] implemente deleting of snapshots
- [ ] provide unit tests for all important parts

Ideas for later:
- automatically create snapshots after each x events, configurable per projection
- automatic clean up of old / not needed snapshots
- create / restore snapshots for multiple projections at once
- dump snapshots to and restore from file system / cloud storage, for quick disaster recovery