### PR TITLE
Provide more details in EventCouldNotBeAppliedException

### DIFF
--- a/Classes/EventListener/EventListenerInvoker.php
+++ b/Classes/EventListener/EventListenerInvoker.php
@@ -232,7 +232,7 @@ final class EventListenerInvoker
         try {
             $this->eventListener->$listenerMethodName($event, $rawEvent);
         } catch (\Throwable $exception) {
-            throw new EventCouldNotBeAppliedException(sprintf('Event "%s" (%s) could not be applied to %s. Sequence number (%d) is not updated', $rawEvent->getIdentifier(), $rawEvent->getType(), \get_class($this->eventListener), $rawEvent->getSequenceNumber()), 1544207001, $exception, $eventEnvelope, $this->eventListener);
+            throw new EventCouldNotBeAppliedException(sprintf('Event "%s" (%s) could not be applied to %s because %s was thrown. Sequence number (%d) is not updated. Original exception (%s) thrown in %s line %s: %s', $rawEvent->getIdentifier(), $rawEvent->getType(), get_class($this->eventListener), get_class($exception), $rawEvent->getSequenceNumber(), $exception->getCode(), $exception->getFile(), $exception->getLine(), $exception->getMessage()), 1544207001, $exception, $eventEnvelope, $this->eventListener);
         }
         if ($this->eventListener instanceof AfterInvokeInterface) {
             $this->eventListener->afterInvoke($eventEnvelope);


### PR DESCRIPTION
When an event could not be applied, an exception is thrown, which is logged. Now the message of this exception contains at least a hint on the original exception message and code, which makes it easier to find the root cause of a problem.